### PR TITLE
use full_image_options in post_detail.html template

### DIFF
--- a/djangocms_blog/templates/djangocms_blog/post_detail.html
+++ b/djangocms_blog/templates/djangocms_blog/post_detail.html
@@ -38,7 +38,7 @@
     </header>
     {% if post.main_image_id %}
     <div class="blog-visual">
-        {% thumbnail post.main_image post.thumbnail_options.size crop=post.thumbnail_options.crop upscale=post.thumbnail_options.upscale subject_location=post.main_image.subject_location  as thumb %}
+        {% thumbnail post.main_image post.full_image_options.size crop=post.full_image_options.crop upscale=post.full_image_options.upscale subject_location=post.main_image.subject_location  as thumb %}
         <img src="{{ thumb.url }}" alt="{{ post.main_image.default_alt_text }}" width="{{ thumb.width }}" height="{{ thumb.height }}" />
     </div>
     {% endif %}


### PR DESCRIPTION
It appeared to me that the BLOG_IMAGE_FULL_SIZE option wasn't doing anything really until I changed the thumbnail options in post_detail.html. Is this how it's meant to be after all? At least that was my impression from the option's description.