### PR TITLE
bugfix NoReverseMatch if category is not translated

### DIFF
--- a/djangocms_blog/templates/djangocms_blog/includes/blog_item.html
+++ b/djangocms_blog/templates/djangocms_blog/includes/blog_item.html
@@ -18,7 +18,9 @@
             <ul class="post-detail tags">
                 {% if post.categories.exists %}
                     {% for category in post.categories.all %}
-                        <li class="category_{{ forloop.counter }}"><a href="{% url 'djangocms_blog:posts-category' category=category.slug %}" class="blog-categories-{{ category.count }}">{{ category.name }}</a>{% if not forloop.last %}, {% endif %}</li>
+                        {% if category.slug %}
+                            <li class="category_{{ forloop.counter }}"><a href="{% url 'djangocms_blog:posts-category' category=category.slug %}" class="blog-categories-{{ category.count }}">{{ category.name }}</a>{% if not forloop.last %}, {% endif %}</li>
+                        {% endif %}
                     {% endfor %}
 			    {% endif %}
                 {% if post.tags.exists %}


### PR DESCRIPTION
error:
```
Exception Type: NoReverseMatch at /en/blog-en/
Exception Value: Reverse for 'posts-category' with arguments '()' and keyword arguments '{'category': ''}' not found. 1 pattern(s) tried: ['en/blog-en/category/(?P<category>[\\w\\.@+-]+)/$']
```

e.g: blog entry in "de" with cagegory in "de" but not in "en" and request the page in "en".