### PR TITLE
Switched Images fieldset name to English default

### DIFF
--- a/djangocms_blog/admin.py
+++ b/djangocms_blog/admin.py
@@ -45,7 +45,7 @@ class PostAdmin(EnhancedModelAdminMixin, FrontendEditableAdminMixin,
                        ('date_published', 'date_published_end', 'enable_comments')),
             'classes': ('collapse',)
         }),
-        ('Immagine', {
+        ('Images', {
             'fields': (('main_image', 'main_image_thumbnail', 'main_image_full'),),
             'classes': ('collapse',)
         }),


### PR DESCRIPTION
Not to be presumptuous but assumed that the Images fieldset name was meant to be in English by default.