### PR TITLE
Move constants from models to settings & blog toolbar menu appearance setting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -366,6 +366,9 @@ Global Settings
 * BLOG_SITEMAP_CHANGEFREQ: List for available changefreqs for sitemap items; (default: **always**,
   **hourly**, **daily**, **weekly**, **monthly**, **yearly**, **never**)
 * BLOG_SITEMAP_CHANGEFREQ_DEFAULT: Default changefreq for sitemap items; (default: ``monthly``)
+* BLOG_CURRENT_POST_IDENTIFIER: Current post identifier in request (default ``djangocms_post_current``)
+* BLOG_CURRENT_NAMESPACE: Current post config identifier in request  (default: ``djangocms_post_current_config``)
+* BLOG_ENABLE_THROUGH_TOOLBAR_MENU: Is the toolbar menu throught whole all applications (default: ``False``)
 
 Read-only settings
 ++++++++++++++++++

--- a/djangocms_blog/models.py
+++ b/djangocms_blog/models.py
@@ -22,8 +22,8 @@ from .cms_appconfig import BlogConfig
 from .managers import GenericDateTaggedManager
 from .settings import get_setting
 
-BLOG_CURRENT_POST_IDENTIFIER = 'djangocms_post_current'
-BLOG_CURRENT_NAMESPACE = 'djangocms_post_current_config'
+BLOG_CURRENT_POST_IDENTIFIER = get_setting('CURRENT_POST_IDENTIFIER')
+BLOG_CURRENT_NAMESPACE = get_setting('CURRENT_NAMESPACE')
 
 
 @python_2_unicode_compatible

--- a/djangocms_blog/settings.py
+++ b/djangocms_blog/settings.py
@@ -101,5 +101,11 @@ def get_setting(name):
         ),
 
         'BLOG_ENABLE_SEARCH': getattr(settings, 'BLOG_ENABLE_SEARCH', True),
+        'BLOG_CURRENT_POST_IDENTIFIER': getattr(
+            settings, 'BLOG_CURRENT_POST_IDENTIFIER', 'djangocms_post_current'),
+        'BLOG_CURRENT_NAMESPACE': getattr(
+            settings, 'BLOG_CURRENT_NAMESPACE', 'djangocms_post_current_config'),
+        'BLOG_ENABLE_THROUGH_TOOLBAR_MENU': getattr(
+            settings, 'BLOG_ENABLE_THROUGH_TOOLBAR_MENU', False),
     }
     return default['BLOG_%s' % name]

--- a/djangocms_blog/views.py
+++ b/djangocms_blog/views.py
@@ -12,7 +12,7 @@ from django.utils.translation import get_language
 from django.views.generic import DetailView, ListView
 from parler.views import TranslatableSlugMixin, ViewUrlMixin
 
-from .models import BLOG_CURRENT_NAMESPACE, BLOG_CURRENT_POST_IDENTIFIER, BlogCategory, Post
+from .models import BlogCategory, Post
 from .settings import get_setting
 
 User = get_user_model()
@@ -43,7 +43,7 @@ class BaseBlogView(AppConfigMixin, ViewUrlMixin):
         )
         if not getattr(self.request, 'toolbar', False) or not self.request.toolbar.edit_mode:
             queryset = queryset.published()
-        setattr(self.request, BLOG_CURRENT_NAMESPACE, self.config)
+        setattr(self.request, get_setting('CURRENT_NAMESPACE'), self.config)
         return queryset
 
     def get_template_names(self):
@@ -89,7 +89,7 @@ class PostDetailView(TranslatableSlugMixin, BaseBlogView, DetailView):
         context = super(PostDetailView, self).get_context_data(**kwargs)
         context['meta'] = self.get_object().as_meta()
         context['use_placeholder'] = get_setting('USE_PLACEHOLDER')
-        setattr(self.request, BLOG_CURRENT_POST_IDENTIFIER, self.get_object())
+        setattr(self.request, get_setting('CURRENT_POST_IDENTIFIER'), self.get_object())
         return context
 
 


### PR DESCRIPTION
Some settings value (``BLOG_CURRENT_POST_IDENTIFIER``, ``BLOG_CURRENT_NAMESPACE``) comes from models.py which will unpossible override cms_toolbare module in project settings untill django not loaded whole application.

Add ``BLOG_ENABLE_THROUGH_TOOLBAR_MENU`` into settings: Controlling toolbar menu appearance, if it True blog toolbar menu will appear through all applications.