### PR TITLE
Post admin's fieldset filter function

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -12,11 +12,16 @@ Contributors
 
 * Christoph Reimers
 * Davide Truffo
+* furiousdave
+* Georgiy Kutsurua
 * Jens Diemer
 * Kamil Gałuszka
 * Leonardo Cavallucci
+* Marco Federighi
 * Max Vyaznikov
 * MotleyTech
 * Nico Schottelius
+* Sami Kalliomäki
 * Stefan Wehrmeyer
+* Sylvain Fankhauser
 * Tadas Dailyda

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@
 History
 -------
 
+0.6.3 (XXXX-XX-XX)
+++++++++++++++++++
+
+* Ensure correct creation of full URL for canonical urls
+* Move constants to settings
+
 0.6.2 (2015-11-16)
 ++++++++++++++++++
 

--- a/djangocms_blog/__init__.py
+++ b/djangocms_blog/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 __author__ = 'Iacopo Spalletti'
 __email__ = 'i.spalletti@nephila.it'
-__version__ = '0.6.2'
+__version__ = '0.6.2.post1'
 
 default_app_config = 'djangocms_blog.apps.BlogAppConfig'


### PR DESCRIPTION
In case when needed custom behavior in post admin fieldsets.

 * BLOG_ADMIN_POST_FIELDSET_FILTER: Callable function to change(add or filter)
  fields to fieldsets for admin post edit form; (default: ``False``). Function simple example::
  
  ```
    def fieldset_filter_function(fsets, request, obj=None):
        if request.user.groups.filter(name='Editor').exists():
            fsets[1][1]['fields'][0].append('author')  # adding 'author' field if user is Editor
        return fsets
```