### PR TITLE
fix migration 0007 to use swappable dependency

### DIFF
--- a/djangocms_blog/migrations/0001_initial.py
+++ b/djangocms_blog/migrations/0001_initial.py
@@ -8,13 +8,17 @@ import filer.fields.image
 import meta_mixin.models
 import taggit_autosuggest.managers
 from django.conf import settings
-from django.db import models, migrations
+from django.db import migrations, models
+from filer.settings import FILER_IMAGE_MODEL
+
+ACTUAL_FILER_IMAGE_MODEL = FILER_IMAGE_MODEL or 'filer.Image'
 
 
 class Migration(migrations.Migration):
 
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        migrations.swappable_dependency(ACTUAL_FILER_IMAGE_MODEL),
         ('cms', '__latest__'),
         ('taggit', '__latest__'),
         ('filer', '__latest__'),
@@ -90,7 +94,7 @@ class Migration(migrations.Migration):
                 ('author', models.ForeignKey(related_name='djangocms_blog_post_author', verbose_name='Author', blank=True, to=settings.AUTH_USER_MODEL, null=True)),
                 ('categories', models.ManyToManyField(related_name='blog_posts', verbose_name='category', to='djangocms_blog.BlogCategory')),
                 ('content', cms.models.fields.PlaceholderField(slotname='post_content', editable=False, to='cms.Placeholder', null=True)),
-                ('main_image', filer.fields.image.FilerImageField(related_name='djangocms_blog_post_image', verbose_name='Main image', blank=True, to='filer.Image', null=True)),
+                ('main_image', filer.fields.image.FilerImageField(related_name='djangocms_blog_post_image', verbose_name='Main image', blank=True, to=ACTUAL_FILER_IMAGE_MODEL, null=True)),
                 ('main_image_full', models.ForeignKey(related_name='djangocms_blog_post_full', verbose_name='Main image full', blank=True, to='cmsplugin_filer_image.ThumbnailOption', null=True)),
                 ('main_image_thumbnail', models.ForeignKey(related_name='djangocms_blog_post_thumbnail', verbose_name='Main image thumbnail', blank=True, to='cmsplugin_filer_image.ThumbnailOption', null=True)),
                 ('tags', taggit_autosuggest.managers.TaggableManager(to='taggit.Tag', through='taggit.TaggedItem', blank=True, help_text='A comma-separated list of tags.', verbose_name='Tags')),

--- a/djangocms_blog/migrations/0004_auto_20150108_1435.py
+++ b/djangocms_blog/migrations/0004_auto_20150108_1435.py
@@ -1,14 +1,18 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
-import filer.fields.image
 import django.db.models.deletion
+import filer.fields.image
+from django.db import migrations, models
+from filer.settings import FILER_IMAGE_MODEL
+
+ACTUAL_FILER_IMAGE_MODEL = FILER_IMAGE_MODEL or 'filer.Image'
 
 
 class Migration(migrations.Migration):
 
     dependencies = [
+        migrations.swappable_dependency(ACTUAL_FILER_IMAGE_MODEL),
         ('djangocms_blog', '0003_auto_20141201_2252'),
     ]
 
@@ -16,7 +20,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='post',
             name='main_image',
-            field=filer.fields.image.FilerImageField(related_name='djangocms_blog_post_image', on_delete=django.db.models.deletion.SET_NULL, verbose_name='Main image', blank=True, to='filer.Image', null=True),
+            field=filer.fields.image.FilerImageField(related_name='djangocms_blog_post_image', on_delete=django.db.models.deletion.SET_NULL, verbose_name='Main image', blank=True, to=ACTUAL_FILER_IMAGE_MODEL, null=True),
             preserve_default=True,
         ),
         migrations.AlterField(

--- a/djangocms_blog/migrations/0007_auto_20150719_0933.py
+++ b/djangocms_blog/migrations/0007_auto_20150719_0933.py
@@ -9,12 +9,14 @@ from django.conf import settings
 from django.db import migrations, models
 from filer.settings import FILER_IMAGE_MODEL
 
+ACTUAL_FILER_IMAGE_MODEL = FILER_IMAGE_MODEL or 'filer.Image'
+
 
 class Migration(migrations.Migration):
 
     dependencies = [
         ('djangocms_blog', '0006_auto_20150214_1907'),
-        migrations.swappable_dependency(FILER_IMAGE_MODEL),
+        migrations.swappable_dependency(ACTUAL_FILER_IMAGE_MODEL),
     ]
 
     operations = [
@@ -101,7 +103,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='post',
             name='main_image',
-            field=filer.fields.image.FilerImageField(on_delete=django.db.models.deletion.SET_NULL, blank=True, verbose_name='main image', to='filer.Image', related_name='djangocms_blog_post_image', null=True),
+            field=filer.fields.image.FilerImageField(on_delete=django.db.models.deletion.SET_NULL, blank=True, verbose_name='main image', to=ACTUAL_FILER_IMAGE_MODEL, related_name='djangocms_blog_post_image', null=True),
             preserve_default=True,
         ),
         migrations.AlterField(

--- a/djangocms_blog/migrations/0007_auto_20150719_0933.py
+++ b/djangocms_blog/migrations/0007_auto_20150719_0933.py
@@ -1,18 +1,20 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
-import filer.fields.image
-import django.utils.timezone
-from django.conf import settings
-import djangocms_text_ckeditor.fields
 import django.db.models.deletion
+import django.utils.timezone
+import djangocms_text_ckeditor.fields
+import filer.fields.image
+from django.conf import settings
+from django.db import migrations, models
+from filer.settings import FILER_IMAGE_MODEL
 
 
 class Migration(migrations.Migration):
 
     dependencies = [
         ('djangocms_blog', '0006_auto_20150214_1907'),
+        migrations.swappable_dependency(FILER_IMAGE_MODEL),
     ]
 
     operations = [


### PR DESCRIPTION
Decided to upgrade djangocms-blog from 0.4smth and I have two issues with migrations so far.

This is to fix the first issue which fails the migration if custom image model is used in filer. To fix this, swappable dependency has to be used, otherwise migration fails with smth like '<custom image model's app> not installed'. Even cmsplugin-filer does this the wrong way, so no surprise here :)

I'll write up an issue my other problem.