### PR TITLE
Fix #202

### DIFF
--- a/djangocms_blog/migrations/0010_auto_20150923_1151.py
+++ b/djangocms_blog/migrations/0010_auto_20150923_1151.py
@@ -4,35 +4,7 @@ from __future__ import unicode_literals
 import aldryn_apphooks_config.fields
 import app_data.fields
 import djangocms_text_ckeditor.fields
-from cms.models import Page
-from cms.utils.i18n import get_language_list
 from django.db import models, migrations
-
-
-def forwards(apps, schema_editor):
-    BlogConfig = apps.get_model('djangocms_blog', 'BlogConfig')
-    BlogConfigTranslation = apps.get_model('djangocms_blog', 'BlogConfigTranslation')
-    Post = apps.get_model('djangocms_blog', 'Post')
-    BlogCategory = apps.get_model('djangocms_blog', 'BlogCategory')
-    GenericBlogPlugin = apps.get_model('djangocms_blog', 'GenericBlogPlugin')
-    LatestPostsPlugin = apps.get_model('djangocms_blog', 'LatestPostsPlugin')
-    AuthorEntriesPlugin = apps.get_model('djangocms_blog', 'AuthorEntriesPlugin')
-    config = None
-    for page in Page.objects.drafts().filter(application_urls='BlogApp'):
-        config = BlogConfig.objects.create(namespace=page.application_namespace)
-        for lang in get_language_list():
-            title = page.get_title(lang)
-            translation = BlogConfigTranslation.objects.create(language_code=lang, master_id=config.pk, app_title=title)
-    if config:
-        for model in (Post, BlogCategory, GenericBlogPlugin, LatestPostsPlugin, AuthorEntriesPlugin):
-            for item in model.objects.all():
-                item.app_config = config
-                item.save()
-
-
-def backwards(apps, schema_editor):
-    # No need for backward data migration
-    pass
 
 
 class Migration(migrations.Migration):
@@ -120,5 +92,4 @@ class Migration(migrations.Migration):
             name='sites',
             field=models.ManyToManyField(to='sites.Site', help_text='Select sites in which to show the post. If none is set it will be visible in all the configured sites.', blank=True, verbose_name='Site(s)'),
         ),
-        migrations.RunPython(forwards, backwards)
     ]

--- a/djangocms_blog/migrations/0014_auto_20160215_1331.py
+++ b/djangocms_blog/migrations/0014_auto_20160215_1331.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from cms.models import Page
+from cms.utils.i18n import get_language_list
+from django.db import migrations, models
+
+
+def forwards(apps, schema_editor):
+    BlogConfig = apps.get_model('djangocms_blog', 'BlogConfig')
+    BlogConfigTranslation = apps.get_model('djangocms_blog', 'BlogConfigTranslation')
+    Post = apps.get_model('djangocms_blog', 'Post')
+    BlogCategory = apps.get_model('djangocms_blog', 'BlogCategory')
+    GenericBlogPlugin = apps.get_model('djangocms_blog', 'GenericBlogPlugin')
+    LatestPostsPlugin = apps.get_model('djangocms_blog', 'LatestPostsPlugin')
+    AuthorEntriesPlugin = apps.get_model('djangocms_blog', 'AuthorEntriesPlugin')
+    config = None
+    for page in Page.objects.drafts().filter(application_urls='BlogApp'):
+        config, created = BlogConfig.objects.get_or_create(namespace=page.application_namespace)
+        if not BlogConfigTranslation.objects.exists():
+            for lang in get_language_list():
+                title = page.get_title(lang)
+                translation = BlogConfigTranslation.objects.create(language_code=lang, master_id=config.pk, app_title=title)
+    if config:
+        for model in (Post, BlogCategory, GenericBlogPlugin, LatestPostsPlugin, AuthorEntriesPlugin):
+            for item in model.objects.filter(app_config__isnull=True):
+                item.app_config = config
+                item.save()
+
+
+def backwards(apps, schema_editor):
+    # No need for backward data migration
+    pass
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('djangocms_blog', '0013_auto_20160201_2235'),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, backwards),
+    ]


### PR DESCRIPTION
Since splitting 0010 into two transaction would probably be a very bad idea, I decided to move data migration stuff from 0010 to a new migration (0014) and adapt the code to do nothing in case data is already migrated (for those users who have successfully run 0010 in it's original form). South migrations don't have this problems because data and schema stuff are in different migrations it seems.