### PR TITLE
Add option to customize the knocker behavior

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
   - TOXENV='pep8'
   - TOXENV='isort'
   - DJANGO='django19' CMS='cms32'
+  - DJANGO='django19' CMS='knocker'
   - DJANGO='django18' CMS='cms32'
   - DJANGO='django18' CMS='cms31'
   - DJANGO='django17' CMS='cms32'
@@ -74,8 +75,12 @@ matrix:
     env: DJANGO='django18' CMS='cms32'
   - python: 2.6
     env: DJANGO='django19' CMS='cms32'
+  - python: 2.6
+    env: DJANGO='django19' CMS='knocker'
   - python: 3.3
     env: DJANGO='django19' CMS='cms32'
+  - python: 3.3
+    env: DJANGO='django19' CMS='knocker'
   - python: 3.5
     env: DJANGO='django16' CMS='cms30'
   - python: 3.5

--- a/README.rst
+++ b/README.rst
@@ -494,6 +494,8 @@ Per-Apphook settings
 * Twitter author handle: Per-Apphook setting for BLOG_TWITTER_AUTHOR
 * Google+ type: Per-Apphook setting for BLOG_GPLUS_TYPE
 * Google+ author name: Per-Apphook setting for BLOG_GPLUS_AUTHOR
+* Send notifications on post publish: Send desktop notifications when a post is published
+* Send notifications on post update: Send desktop notifications when a post is updated
 
 
 Import from Wordpress

--- a/djangocms_blog/admin.py
+++ b/djangocms_blog/admin.py
@@ -191,6 +191,12 @@ class BlogConfigAdmin(BaseAppHookConfig, TranslatableAdmin):
                 ),
                 'classes': ('collapse',)
             }),
+            ('Notifications', {
+                'fields': (
+                    'config.send_knock_create', 'config.send_knock_update'
+                ),
+                'classes': ('collapse',)
+            }),
             ('Sitemap', {
                 'fields': (
                     'config.sitemap_changefreq', 'config.sitemap_priority',

--- a/djangocms_blog/cms_appconfig.py
+++ b/djangocms_blog/cms_appconfig.py
@@ -127,7 +127,7 @@ class BlogConfigForm(AppDataForm):
     )
 
     send_knock_create = forms.BooleanField(
-        label=_('Send notifications on post creation'), required=False, initial=False,
+        label=_('Send notifications on post publish'), required=False, initial=False,
         help_text=_('Emits a desktop notification -if enabled- when publishing a new post')
     )
     send_knock_update = forms.BooleanField(

--- a/djangocms_blog/cms_appconfig.py
+++ b/djangocms_blog/cms_appconfig.py
@@ -125,4 +125,13 @@ class BlogConfigForm(AppDataForm):
         max_length=200, label=_('Google+ author name'), required=False,
         initial=get_setting('GPLUS_AUTHOR')
     )
+
+    send_knock_create = forms.BooleanField(
+        label=_('Send notifications on post creation'), required=False, initial=False,
+        help_text=_('Emits a desktop notification -if enabled- when publishing a new post')
+    )
+    send_knock_update = forms.BooleanField(
+        label=_('Send notifications on post update'), required=False, initial=False,
+        help_text=_('Emits a desktop notification -if enabled- when editing a published post')
+    )
 setup_config(BlogConfigForm, BlogConfig)

--- a/djangocms_blog/models.py
+++ b/djangocms_blog/models.py
@@ -8,8 +8,6 @@ from django.conf import settings as dj_settings
 from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse
 from django.db import models
-from django.db.models.signals import pre_save
-from django.dispatch import receiver
 from django.utils import timezone
 from django.utils.encoding import force_text, python_2_unicode_compatible
 from django.utils.html import escape, strip_tags

--- a/tests/base.py
+++ b/tests/base.py
@@ -117,8 +117,12 @@ class BaseTest(BaseTestCase):
             namespace='sample_app2', app_title='app2', object_name='Article'
         )
         cls.app_config_1.app_data.config.paginate_by = 1
+        cls.app_config_1.app_data.config.send_knock_create = True
+        cls.app_config_1.app_data.config.send_knock_update = True
         cls.app_config_1.save()
         cls.app_config_2.app_data.config.paginate_by = 2
+        cls.app_config_2.app_data.config.send_knock_create = True
+        cls.app_config_2.app_data.config.send_knock_update = True
         cls.app_config_2.save()
         cls.app_configs = {
             'sample_app': cls.app_config_1,


### PR DESCRIPTION
This is the last step for proper knocker integration
Is now possible to enable knocker per apphook config and if emit knocks on post publishing and / or updates