### PR TITLE
Only list posts from the current site

### DIFF
--- a/djangocms_blog/views.py
+++ b/djangocms_blog/views.py
@@ -44,7 +44,7 @@ class BaseBlogView(AppConfigMixin, ViewUrlMixin):
         if not getattr(self.request, 'toolbar', False) or not self.request.toolbar.edit_mode:
             queryset = queryset.published()
         setattr(self.request, get_setting('CURRENT_NAMESPACE'), self.config)
-        return queryset
+        return queryset.on_site()
 
     def get_template_names(self):
         template_path = (self.config and self.config.template_prefix) or 'djangocms_blog'


### PR DESCRIPTION
This fixes a regression introduced by a1b2c5630528f0edb984888533775a737a612f83 in which the `on_site()` filter from the blog posts list view was removed.