### PR TITLE
Handle the case when there is no menu_structure in config

### DIFF
--- a/djangocms_blog/cms_menus.py
+++ b/djangocms_blog/cms_menus.py
@@ -125,7 +125,11 @@ class BlogNavModifier(Modifier):
         if app and app.app_config:
             namespace = resolve(request.path).namespace
             config = app.get_config(namespace)
-        if config and config.menu_structure != MENU_TYPE_CATEGORIES:
+        try:
+            if config and config.menu_structure != MENU_TYPE_CATEGORIES:
+                return nodes
+        except AttributeError:
+            # in case `menu_structure` is not present in config
             return nodes
         if post_cut:
             return nodes


### PR DESCRIPTION
```
config = app.get_config(namespace)
```
It's possible for `config` to be an instance of another apps config. So it will not have `menu_structure` and we get HTTP 500