### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ Features
 Documentation
 -------------
 
-Check documentation at http://djangocms-blog.readthedocs.io/en/latest/
+Check documentation at https://djangocms-blog.readthedocs.io/en/latest/
 
 Known djangocms-blog websites
 +++++++++++++++++++++++++++++

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -168,5 +168,5 @@ django-knocker
 ``djangocms-blog`` is integrated with `django-knocker <https://github.com/nephila/django-knocker>`_
 to provide real time desktop notifications.
 
-See `django-knocker documentation <https://django-knocker.readthedocs.org/>`_ for how to configure
+See `django-knocker documentation <https://django-knocker.readthedocs.io/>`_ for how to configure
 knocker.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -62,7 +62,7 @@ suited for your deployment.
 
     url(r'^taggit_autosuggest/', include('taggit_autosuggest.urls')),
 
-* To start your blog you need to use `AppHooks from django CMS <http://django-cms.readthedocs.org/en/support-3.0.x/how_to/apphooks.html>`_
+* To start your blog you need to use `AppHooks from django CMS <http://docs.django-cms.org/en/latest/how_to/apphooks.html>`_
   to add the blog to a django CMS page; this step is not required when using
   `Auto setup <auto_setup>`_:
 
@@ -79,7 +79,7 @@ suited for your deployment.
              new **Application configuration**
 
 * Add and edit blog by creating them in the admin or using the toolbar,
-  and the use the `django CMS frontend editor <http://django-cms.readthedocs.org/en/support-3.0.x/user/reference/page_admin.html#the-interface>`_
+  and the use the `django CMS frontend editor <http://docs.django-cms.org/en/latest/user/reference/page_admin.html>`_
   to edit the blog content:
 
   * Create a new blog entry in django admin backend or from the toolbar
@@ -97,10 +97,10 @@ Dependency applications may need configuration to work properly.
 
 Please, refer to each application documentation on details.
 
-* django-filer: http://django-filer.readthedocs.org
+* django-filer: https://django-filer.readthedocs.io
 * django-meta: https://github.com/nephila/django-meta#installation
 * django-meta-mixin: https://github.com/nephila/django-meta-mixin#installation
-* django-parler: http://django-parler.readthedocs.org/en/latest/quickstart.html#configuration
+* django-parler: https://django-parler.readthedocs.io/en/latest/quickstart.html#configuration
 * django-taggit-autosuggest: https://bitbucket.org/fabian/django-taggit-autosuggest
 
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.