### PR TITLE
Feature-add: allow by-plugin definition of template folder (Issue #295)

### DIFF
--- a/djangocms_blog/cms_plugins.py
+++ b/djangocms_blog/cms_plugins.py
@@ -18,9 +18,13 @@ class BlogPlugin(CMSPluginBase):
 
     def get_render_template(self, context, instance, placeholder):
         if instance.app_config and instance.app_config.template_prefix:
-            return os.path.join(instance.app_config.template_prefix, self.base_render_template)
+            return os.path.join(instance.app_config.template_prefix,
+                                instance.template_folder,
+                                self.base_render_template)
         else:
-            return os.path.join('djangocms_blog', self.base_render_template)
+            return os.path.join('djangocms_blog',
+                                instance.template_folder,
+                                self.base_render_template)
 
 
 class BlogLatestEntriesPlugin(BlogPlugin):
@@ -34,7 +38,7 @@ class BlogLatestEntriesPlugin(BlogPlugin):
     filter_horizontal = ('categories',)
     fields = ('app_config', 'latest_posts', 'tags', 'categories')
     cache = False
-    base_render_template = 'plugins/latest_entries.html'
+    base_render_template = 'latest_entries.html'
 
     def render(self, context, instance, placeholder):
         context = super(BlogLatestEntriesPlugin, self).render(context, instance, placeholder)
@@ -52,7 +56,7 @@ class BlogLatestEntriesPluginCached(BlogPlugin):
     form = LatestEntriesForm
     filter_horizontal = ('categories',)
     fields = ('app_config', 'latest_posts', 'tags', 'categories')
-    base_render_template = 'plugins/latest_entries.html'
+    base_render_template = 'latest_entries.html'
 
     def render(self, context, instance, placeholder):
         context = super(BlogLatestEntriesPluginCached, self).render(context, instance, placeholder)
@@ -65,7 +69,7 @@ class BlogAuthorPostsPlugin(BlogPlugin):
     module = get_setting('PLUGIN_MODULE_NAME')
     name = get_setting('AUTHOR_POSTS_PLUGIN_NAME')
     model = AuthorEntriesPlugin
-    base_render_template = 'plugins/authors.html'
+    base_render_template = 'authors.html'
     filter_horizontal = ['authors']
 
     def render(self, context, instance, placeholder):
@@ -78,7 +82,7 @@ class BlogTagsPlugin(BlogPlugin):
     module = get_setting('PLUGIN_MODULE_NAME')
     name = get_setting('TAGS_PLUGIN_NAME')
     model = GenericBlogPlugin
-    base_render_template = 'plugins/tags.html'
+    base_render_template = 'tags.html'
 
     def render(self, context, instance, placeholder):
         context = super(BlogTagsPlugin, self).render(context, instance, placeholder)
@@ -91,7 +95,7 @@ class BlogCategoryPlugin(BlogPlugin):
     module = get_setting('PLUGIN_MODULE_NAME')
     name = get_setting('CATEGORY_PLUGIN_NAME')
     model = GenericBlogPlugin
-    base_render_template = 'plugins/categories.html'
+    base_render_template = 'categories.html'
 
     def render(self, context, instance, placeholder):
         context = super(BlogCategoryPlugin, self).render(context, instance, placeholder)
@@ -111,7 +115,7 @@ class BlogArchivePlugin(BlogPlugin):
     module = get_setting('PLUGIN_MODULE_NAME')
     name = get_setting('ARCHIVE_PLUGIN_NAME')
     model = GenericBlogPlugin
-    base_render_template = 'plugins/archive.html'
+    base_render_template = 'archive.html'
 
     def render(self, context, instance, placeholder):
         context = super(BlogArchivePlugin, self).render(context, instance, placeholder)

--- a/djangocms_blog/cms_plugins.py
+++ b/djangocms_blog/cms_plugins.py
@@ -86,7 +86,7 @@ class BlogTagsPlugin(BlogPlugin):
     name = get_setting('TAGS_PLUGIN_NAME')
     model = GenericBlogPlugin
     base_render_template = 'tags.html'
-    exclude = ['template_folder'] if len(get_setting('PLUGIN_TEMPLATE_FOLDERS'))>=1 else []
+    exclude = ['template_folder'] if len(get_setting('PLUGIN_TEMPLATE_FOLDERS')) >= 1 else []
 
     def render(self, context, instance, placeholder):
         context = super(BlogTagsPlugin, self).render(context, instance, placeholder)
@@ -100,7 +100,7 @@ class BlogCategoryPlugin(BlogPlugin):
     name = get_setting('CATEGORY_PLUGIN_NAME')
     model = GenericBlogPlugin
     base_render_template = 'categories.html'
-    exclude = ['template_folder'] if len(get_setting('PLUGIN_TEMPLATE_FOLDERS'))>=1 else []
+    exclude = ['template_folder'] if len(get_setting('PLUGIN_TEMPLATE_FOLDERS')) >= 1 else []
 
     def render(self, context, instance, placeholder):
         context = super(BlogCategoryPlugin, self).render(context, instance, placeholder)

--- a/djangocms_blog/cms_plugins.py
+++ b/djangocms_blog/cms_plugins.py
@@ -37,7 +37,7 @@ class BlogLatestEntriesPlugin(BlogPlugin):
     form = LatestEntriesForm
     filter_horizontal = ('categories',)
     fields = ['app_config', 'latest_posts', 'tags', 'categories'] + \
-        ['template_folder'] if len(get_setting('PLUGIN_TEMPLATE_FOLDERS'))>1 else []
+        ['template_folder'] if len(get_setting('PLUGIN_TEMPLATE_FOLDERS')) > 1 else []
     cache = False
     base_render_template = 'latest_entries.html'
 
@@ -56,8 +56,8 @@ class BlogLatestEntriesPluginCached(BlogPlugin):
     model = LatestPostsPlugin
     form = LatestEntriesForm
     filter_horizontal = ('categories',)
-    fields = ['app_config', 'latest_posts', 'tags', 'categories']+ \
-        ['template_folder'] if len(get_setting('PLUGIN_TEMPLATE_FOLDERS'))>1 else []
+    fields = ['app_config', 'latest_posts', 'tags', 'categories'] + \
+        ['template_folder'] if len(get_setting('PLUGIN_TEMPLATE_FOLDERS')) > 1 else []
     base_render_template = 'latest_entries.html'
 
     def render(self, context, instance, placeholder):
@@ -73,7 +73,7 @@ class BlogAuthorPostsPlugin(BlogPlugin):
     model = AuthorEntriesPlugin
     base_render_template = 'authors.html'
     filter_horizontal = ['authors']
-    exclude = ['template_folder'] if len(get_setting('PLUGIN_TEMPLATE_FOLDERS'))>=1 else []
+    exclude = ['template_folder'] if len(get_setting('PLUGIN_TEMPLATE_FOLDERS')) >= 1 else []
 
     def render(self, context, instance, placeholder):
         context = super(BlogAuthorPostsPlugin, self).render(context, instance, placeholder)
@@ -121,7 +121,7 @@ class BlogArchivePlugin(BlogPlugin):
     name = get_setting('ARCHIVE_PLUGIN_NAME')
     model = GenericBlogPlugin
     base_render_template = 'archive.html'
-    exclude = ['template_folder'] if len(get_setting('PLUGIN_TEMPLATE_FOLDERS'))>=1 else []
+    exclude = ['template_folder'] if len(get_setting('PLUGIN_TEMPLATE_FOLDERS')) >= 1 else []
 
     def render(self, context, instance, placeholder):
         context = super(BlogArchivePlugin, self).render(context, instance, placeholder)

--- a/djangocms_blog/cms_plugins.py
+++ b/djangocms_blog/cms_plugins.py
@@ -36,7 +36,8 @@ class BlogLatestEntriesPlugin(BlogPlugin):
     model = LatestPostsPlugin
     form = LatestEntriesForm
     filter_horizontal = ('categories',)
-    fields = ('app_config', 'latest_posts', 'tags', 'categories')
+    fields = ['app_config', 'latest_posts', 'tags', 'categories'] + \
+        ['template_folder'] if len(get_setting('PLUGIN_TEMPLATE_FOLDERS'))>1 else []
     cache = False
     base_render_template = 'latest_entries.html'
 
@@ -55,7 +56,8 @@ class BlogLatestEntriesPluginCached(BlogPlugin):
     model = LatestPostsPlugin
     form = LatestEntriesForm
     filter_horizontal = ('categories',)
-    fields = ('app_config', 'latest_posts', 'tags', 'categories')
+    fields = ['app_config', 'latest_posts', 'tags', 'categories']+ \
+        ['template_folder'] if len(get_setting('PLUGIN_TEMPLATE_FOLDERS'))>1 else []
     base_render_template = 'latest_entries.html'
 
     def render(self, context, instance, placeholder):
@@ -71,6 +73,7 @@ class BlogAuthorPostsPlugin(BlogPlugin):
     model = AuthorEntriesPlugin
     base_render_template = 'authors.html'
     filter_horizontal = ['authors']
+    exclude = ['template_folder'] if len(get_setting('PLUGIN_TEMPLATE_FOLDERS'))>=1 else []
 
     def render(self, context, instance, placeholder):
         context = super(BlogAuthorPostsPlugin, self).render(context, instance, placeholder)
@@ -83,6 +86,7 @@ class BlogTagsPlugin(BlogPlugin):
     name = get_setting('TAGS_PLUGIN_NAME')
     model = GenericBlogPlugin
     base_render_template = 'tags.html'
+    exclude = ['template_folder'] if len(get_setting('PLUGIN_TEMPLATE_FOLDERS'))>=1 else []
 
     def render(self, context, instance, placeholder):
         context = super(BlogTagsPlugin, self).render(context, instance, placeholder)
@@ -96,6 +100,7 @@ class BlogCategoryPlugin(BlogPlugin):
     name = get_setting('CATEGORY_PLUGIN_NAME')
     model = GenericBlogPlugin
     base_render_template = 'categories.html'
+    exclude = ['template_folder'] if len(get_setting('PLUGIN_TEMPLATE_FOLDERS'))>=1 else []
 
     def render(self, context, instance, placeholder):
         context = super(BlogCategoryPlugin, self).render(context, instance, placeholder)
@@ -116,6 +121,7 @@ class BlogArchivePlugin(BlogPlugin):
     name = get_setting('ARCHIVE_PLUGIN_NAME')
     model = GenericBlogPlugin
     base_render_template = 'archive.html'
+    exclude = ['template_folder'] if len(get_setting('PLUGIN_TEMPLATE_FOLDERS'))>=1 else []
 
     def render(self, context, instance, placeholder):
         context = super(BlogArchivePlugin, self).render(context, instance, placeholder)

--- a/djangocms_blog/migrations/0024_auto_20160706_1524.py
+++ b/djangocms_blog/migrations/0024_auto_20160706_1524.py
@@ -14,16 +14,16 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='authorentriesplugin',
             name='template_folder',
-            field=models.CharField(default='Default template', verbose_name='Plugin template', max_length=40, help_text='Select plugin template to load for this instance', choices=[('plugins', 'Default template')]),
+            field=models.CharField(default='Default template', verbose_name='Plugin template', max_length=200, help_text='Select plugin template to load for this instance', choices=[('plugins', 'Default template')]),
         ),
         migrations.AddField(
             model_name='genericblogplugin',
             name='template_folder',
-            field=models.CharField(default='Default template', verbose_name='Plugin template', max_length=40, help_text='Select plugin template to load for this instance', choices=[('plugins', 'Default template')]),
+            field=models.CharField(default='Default template', verbose_name='Plugin template', max_length=200, help_text='Select plugin template to load for this instance', choices=[('plugins', 'Default template')]),
         ),
         migrations.AddField(
             model_name='latestpostsplugin',
             name='template_folder',
-            field=models.CharField(default='Default template', verbose_name='Plugin template', max_length=40, help_text='Select plugin template to load for this instance', choices=[('plugins', 'Default template')]),
+            field=models.CharField(default='Default template', verbose_name='Plugin template', max_length=200, help_text='Select plugin template to load for this instance', choices=[('plugins', 'Default template')]),
         ),
     ]

--- a/djangocms_blog/migrations/0024_auto_20160706_1524.py
+++ b/djangocms_blog/migrations/0024_auto_20160706_1524.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('djangocms_blog', '0023_auto_20160626_1539'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='authorentriesplugin',
+            name='template_folder',
+            field=models.CharField(default='Default template', verbose_name='Plugin template', max_length=40, help_text='Select plugin template to load for this instance', choices=[('plugins', 'Default template')]),
+        ),
+        migrations.AddField(
+            model_name='genericblogplugin',
+            name='template_folder',
+            field=models.CharField(default='Default template', verbose_name='Plugin template', max_length=40, help_text='Select plugin template to load for this instance', choices=[('plugins', 'Default template')]),
+        ),
+        migrations.AddField(
+            model_name='latestpostsplugin',
+            name='template_folder',
+            field=models.CharField(default='Default template', verbose_name='Plugin template', max_length=40, help_text='Select plugin template to load for this instance', choices=[('plugins', 'Default template')]),
+        ),
+    ]

--- a/djangocms_blog/models.py
+++ b/djangocms_blog/models.py
@@ -33,6 +33,7 @@ from .settings import get_setting
 
 BLOG_CURRENT_POST_IDENTIFIER = get_setting('CURRENT_POST_IDENTIFIER')
 BLOG_CURRENT_NAMESPACE = get_setting('CURRENT_NAMESPACE')
+BLOG_PLUGIN_TEMPLATE_FOLDERS = get_setting('PLUGIN_TEMPLATE_FOLDERS')
 
 try:  # pragma: no cover
     from cmsplugin_filer_image.models import ThumbnailOption  # NOQA
@@ -377,6 +378,13 @@ class BasePostPlugin(CMSPlugin):
     )
     current_site = models.BooleanField(
         _('current site'), default=True, help_text=_('Select items from the current site only')
+    )
+    template_folder = models.CharField(
+        max_length = 40,
+        verbose_name = _('Plugin template'),
+        help_text = _('Select plugin template to load for this instance'),
+        default = BLOG_PLUGIN_TEMPLATE_FOLDERS[0][1],
+        choices = BLOG_PLUGIN_TEMPLATE_FOLDERS
     )
 
     class Meta:

--- a/djangocms_blog/models.py
+++ b/djangocms_blog/models.py
@@ -380,10 +380,10 @@ class BasePostPlugin(CMSPlugin):
         _('current site'), default=True, help_text=_('Select items from the current site only')
     )
     template_folder = models.CharField(
-        max_length=40,
+        max_length=200,
         verbose_name=_('Plugin template'),
         help_text=_('Select plugin template to load for this instance'),
-        default=BLOG_PLUGIN_TEMPLATE_FOLDERS[0][1],
+        default=BLOG_PLUGIN_TEMPLATE_FOLDERS[0][0],
         choices=BLOG_PLUGIN_TEMPLATE_FOLDERS
     )
 

--- a/djangocms_blog/models.py
+++ b/djangocms_blog/models.py
@@ -380,11 +380,11 @@ class BasePostPlugin(CMSPlugin):
         _('current site'), default=True, help_text=_('Select items from the current site only')
     )
     template_folder = models.CharField(
-        max_length = 40,
-        verbose_name = _('Plugin template'),
-        help_text = _('Select plugin template to load for this instance'),
-        default = BLOG_PLUGIN_TEMPLATE_FOLDERS[0][1],
-        choices = BLOG_PLUGIN_TEMPLATE_FOLDERS
+        max_length=40,
+        verbose_name=_('Plugin template'),
+        help_text=_('Select plugin template to load for this instance'),
+        default=BLOG_PLUGIN_TEMPLATE_FOLDERS[0][1],
+        choices=BLOG_PLUGIN_TEMPLATE_FOLDERS
     )
 
     class Meta:

--- a/djangocms_blog/settings.py
+++ b/djangocms_blog/settings.py
@@ -136,7 +136,7 @@ def get_setting(name):
             settings, 'BLOG_LIVEBLOG_PLUGINS', ('LiveblogPlugin',)),
 
         'BLOG_PLUGIN_TEMPLATE_FOLDERS': getattr(
-            settings, 'BLOG_PLUGIN_TEMPLATE_FOLDERS', (('plugins', _('Default template')),)  ),
+            settings, 'BLOG_PLUGIN_TEMPLATE_FOLDERS', (('plugins', _('Default template')),)),
 
     }
     return default['BLOG_%s' % name]

--- a/djangocms_blog/settings.py
+++ b/djangocms_blog/settings.py
@@ -135,5 +135,8 @@ def get_setting(name):
         'BLOG_LIVEBLOG_PLUGINS': getattr(
             settings, 'BLOG_LIVEBLOG_PLUGINS', ('LiveblogPlugin',)),
 
+        'BLOG_PLUGIN_TEMPLATE_FOLDERS': getattr(
+            settings, 'BLOG_PLUGIN_TEMPLATE_FOLDERS', (('plugins', _('Default template')),)  ),
+
     }
     return default['BLOG_%s' % name]

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -149,6 +149,25 @@ To use this feature provide a directory name in **Template prefix** field in
 the **Apphook configuration** admin (in *Layout* section): it will be the
 root of your custom templates set.
 
+****************
+Plugin Templates
+****************
+
+Plugin templates live in the ``plugins`` folder of the folder specified by the **Template prefix**, or by default ``djangocms_blog``.
+
+By defining the setting ``BLOG_PLUGIN_TEMPLATE_FOLDERS`` you can allow multiple sets of plugin templates allowing for different views per plugin instance. You could, for example, have a plugin displaying latest posts as a list, a table or in masonry style. 
+
+To use this feature define ``BLOG_PLUGIN_TEMPLATE_FOLDERS`` as a list of available templates. Each item of this list itself is a list of the form ``('[folder_name]', '[verbose name]')``. Example:
+
+	BLOG_PLUGIN_TEMPLATE_FOLDERS = (
+		('plugins', _('Default template') ),    # reads from "templates/djangocms_blog/plugins/
+		('timeline', _('Vertical timeline') ),	# reads from "templates/djangocms_blog/vertical/
+		('masonry', _('Masonry style') ),       # reads from "templates/djangocms_blog/masonry/
+	)
+
+
+Once defined, the plugin admin interface will allow content managers to select which template the plugin will use.
+
 .. _sitemap:
 
 *******

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -155,16 +155,15 @@ Plugin Templates
 
 Plugin templates live in the ``plugins`` folder of the folder specified by the **Template prefix**, or by default ``djangocms_blog``.
 
-By defining the setting ``BLOG_PLUGIN_TEMPLATE_FOLDERS`` you can allow multiple sets of plugin templates allowing for different views per plugin instance. You could, for example, have a plugin displaying latest posts as a list, a table or in masonry style. 
+By defining the setting ``BLOG_PLUGIN_TEMPLATE_FOLDERS`` you can allow multiple sets of plugin templates allowing for different views per plugin instance. You could, for example, have a plugin displaying latest posts as a list, a table or in masonry style.
 
 To use this feature define ``BLOG_PLUGIN_TEMPLATE_FOLDERS`` as a list of available templates. Each item of this list itself is a list of the form ``('[folder_name]', '[verbose name]')``. Example:
 
-	BLOG_PLUGIN_TEMPLATE_FOLDERS = (
-		('plugins', _('Default template') ),    # reads from "templates/djangocms_blog/plugins/
-		('timeline', _('Vertical timeline') ),	# reads from "templates/djangocms_blog/vertical/
-		('masonry', _('Masonry style') ),       # reads from "templates/djangocms_blog/masonry/
-	)
-
+    BLOG_PLUGIN_TEMPLATE_FOLDERS = (
+        ('plugins', _('Default template')),    # reads from templates/djangocms_blog/plugins/
+        ('timeline', _('Vertical timeline')),  # reads from templates/djangocms_blog/vertical/
+        ('masonry', _('Masonry style')),       # reads from templates/djangocms_blog/masonry/
+    )
 
 Once defined, the plugin admin interface will allow content managers to select which template the plugin will use.
 

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -153,11 +153,17 @@ root of your custom templates set.
 Plugin Templates
 ****************
 
-Plugin templates live in the ``plugins`` folder of the folder specified by the **Template prefix**, or by default ``djangocms_blog``.
+Plugin templates live in the ``plugins`` folder of the folder specified by the **Template prefix**,
+or by default ``djangocms_blog``.
 
-By defining the setting ``BLOG_PLUGIN_TEMPLATE_FOLDERS`` you can allow multiple sets of plugin templates allowing for different views per plugin instance. You could, for example, have a plugin displaying latest posts as a list, a table or in masonry style.
+By defining the setting ``BLOG_PLUGIN_TEMPLATE_FOLDERS`` you can allow multiple sets of
+plugin templates allowing for different views per plugin instance. You could, for example,
+have a plugin displaying latest posts as a list, a table or in masonry style.
 
-To use this feature define ``BLOG_PLUGIN_TEMPLATE_FOLDERS`` as a list of available templates. Each item of this list itself is a list of the form ``('[folder_name]', '[verbose name]')``. Example:
+To use this feature define ``BLOG_PLUGIN_TEMPLATE_FOLDERS`` as a list of available templates.
+Each item of this list itself is a list of the form ``('[folder_name]', '[verbose name]')``.
+
+Example:::
 
     BLOG_PLUGIN_TEMPLATE_FOLDERS = (
         ('plugins', _('Default template')),    # reads from templates/djangocms_blog/plugins/

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -91,6 +91,9 @@ Global Settings
 * BLOG_FEED_INSTANT_ITEMS: Number of items in Instant Article feed
 * BLOG_FEED_LATEST_ITEMS: Number of items in latest items feed
 * BLOG_FEED_TAGS_ITEMS: Number of items in per tags feed
+* BLOG_PLUGIN_TEMPLATE_FOLDERS: (Sub-)folder from which the plugin templates are loaded.
+The default folder is `plugins`. It goes into the `djangocms_blog` template folder (or, if set, the folder named in the app hook). This allows, e.g., different templates for showing a post list as tables, columns, ... . New templates have the same names as the standard templates in the `plugins` folder (`latest_entries.html`, `authors.html`, `tags.html`, `categories.html`, `archive.html`). Default behavior corresponds to this setting being `( ("plugins", _("Default template") )`. To add new templates add to this setting, e.g., `('timeline', _('Vertical timeline') )`.
+
 
 ******************
 Read-only settings

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -91,8 +91,7 @@ Global Settings
 * BLOG_FEED_INSTANT_ITEMS: Number of items in Instant Article feed
 * BLOG_FEED_LATEST_ITEMS: Number of items in latest items feed
 * BLOG_FEED_TAGS_ITEMS: Number of items in per tags feed
-* BLOG_PLUGIN_TEMPLATE_FOLDERS: (Sub-)folder from which the plugin templates are loaded.
-The default folder is `plugins`. It goes into the `djangocms_blog` template folder (or, if set, the folder named in the app hook). This allows, e.g., different templates for showing a post list as tables, columns, ... . New templates have the same names as the standard templates in the `plugins` folder (`latest_entries.html`, `authors.html`, `tags.html`, `categories.html`, `archive.html`). Default behavior corresponds to this setting being `( ("plugins", _("Default template") )`. To add new templates add to this setting, e.g., `('timeline', _('Vertical timeline') )`.
+* BLOG_PLUGIN_TEMPLATE_FOLDERS: (Sub-)folder from which the plugin templates are loaded. The default folder is ``plugins``. It goes into the ``djangocms_blog`` template folder (or, if set, the folder named in the app hook). This allows, e.g., different templates for showing a post list as tables, columns, ... . New templates have the same names as the standard templates in the ``plugins`` folder (``latest_entries.html``, ``authors.html``, ``tags.html``, ``categories.html``, ``archive.html``). Default behavior corresponds to this setting being ``( ("plugins", _("Default template") )``. To add new templates add to this setting, e.g., ``('timeline', _('Vertical timeline') )``.
 
 
 ******************

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -189,11 +189,18 @@ class PluginTest(BaseTest):
 
         context = self.get_plugin_context(pages[0], 'en', plugin)
         plugin_class = plugin.get_plugin_class_instance()
-        self.assertEqual(plugin_class.get_render_template(context, plugin, ph), os.path.join('djangocms_blog', plugin_class.base_render_template))
+        self.assertEqual(plugin_class.get_render_template(context, plugin, ph),
+            os.path.join('djangocms_blog', plugin.template_folder, plugin_class.base_render_template))
 
         self.app_config_1.app_data.config.template_prefix = 'whatever'
         self.app_config_1.save()
-        self.assertEqual(plugin_class.get_render_template(context, plugin, ph), os.path.join('whatever', plugin_class.base_render_template))
+        tmp = plugin.template_folder
+        plugin.template_folder = 'whereever'
+        plugin.save()
+        self.assertEqual(plugin_class.get_render_template(context, plugin, ph),
+            os.path.join('whatever', 'whereever', plugin_class.base_render_template))
+        plugin.template_folder = tmp
+        plugin.save()
         self.app_config_1.app_data.config.template_prefix = ''
         self.app_config_1.save()
 


### PR DESCRIPTION
This request adds a field to each plugin type that allows to specify a (sub-)folder from which the plugin templates are loaded. Default folder is "plugins". It goes into the "djangocms_blog" template folder (or, if set, the folder named in the app hook).

This allows, e.g., different templates for showing a post list as tables, columns, or you name it.

New templates have the same names as the standard templates in the "plugins" folder ("latest_entries.html", "authors.html", "tags.html", "categories.html", "archive.html"). The folder options can be defined in a new setting called BLOG_PLUGIN_TEMPLATE_FOLDERS. It's default is "( ("plugins", _("Default template") )" to be compatible with existing configurations.

To add new templates write in settings.py, e.g.,

BLOG_PLUGIN_TEMPLATE_FOLDERS = (
('plugins', _('Default template') ), 	# reads from "templates/djangocms_blog/plugins/
('timeline', _('Vertical timeline') ),	# reads from "templates/djangocms_blog/vertical/
('masonry', _('Masonry style') ),  	# reads from "templates/djangocms_blog/masonry/
)

Fix #295 