### PR TITLE
on site in manager

### DIFF
--- a/djangocms_blog/managers.py
+++ b/djangocms_blog/managers.py
@@ -157,6 +157,9 @@ class GenericDateTaggedManager(TaggedFilterItem, AppHookConfigTranslatableManage
     def filter_by_language(self, language, current_site=True):
         return self.get_queryset().filter_by_language(language, current_site)
 
+    def on_site(self, site=None):
+        return self.get_queryset().on_site(site)
+
     def get_months(self, queryset=None, current_site=True):
         """
         Get months with aggregate count (how much posts is in the month).


### PR DESCRIPTION
GenericDateTaggedManager does not have on_site method
but [here](https://github.com/nephila/djangocms-blog/blob/develop/djangocms_blog/models.py#L409) we call it