### PR TITLE
Check that a post has a url when generating the sitemap.

### DIFF
--- a/djangocms_blog/sitemaps/__init__.py
+++ b/djangocms_blog/sitemaps/__init__.py
@@ -3,10 +3,12 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 from cms.utils import get_language_list
 from django.contrib.sitemaps import Sitemap
+
 try:
     from django.urls.exceptions import NoReverseMatch
 except ImportError:
-    from django.conf.urls.exceptions import NoReverseMatch
+    from django.core.urlresolvers import NoReverseMatch
+
 from parler.utils.context import smart_override
 
 from ..models import Post

--- a/djangocms_blog/sitemaps/__init__.py
+++ b/djangocms_blog/sitemaps/__init__.py
@@ -14,8 +14,6 @@ except ImportError:
     from django.core.urlresolvers import NoReverseMatch
 
 
-
-
 class BlogSitemap(Sitemap):
 
     def __init__(self, *args, **kwargs):

--- a/djangocms_blog/sitemaps/__init__.py
+++ b/djangocms_blog/sitemaps/__init__.py
@@ -15,6 +15,10 @@ from ..settings import get_setting
 
 class BlogSitemap(Sitemap):
 
+    def __init__(self, *args, **kwargs):
+        super(BlogSitemap, self).__init__(*args, **kwargs)
+        self.url_cache = {}
+
     def priority(self, obj):
         if obj and obj.app_config:
             return obj.app_config.sitemap_priority
@@ -27,18 +31,21 @@ class BlogSitemap(Sitemap):
 
     def location(self, obj):
         with smart_override(obj.get_current_language()):
-            return obj.get_absolute_url(obj.get_current_language())
+            return self.url_cache[obj.get_current_language()][obj]
 
     def items(self):
         items = []
+        self.url_cache.clear()
         for lang in get_language_list():
+            self.url_cache[lang] = {}
             posts = Post.objects.translated(lang).language(lang).published()
             for post in posts:
                 # check if the post actually has a url before appending
                 # if a post is published but the associated app config is not
                 # then this post will not have a url
                 try:
-                    post.get_absolute_url()
+                    with smart_override(post.get_current_language()):
+                        self.url_cache[lang][post] = post.get_absolute_url()
                 except NoReverseMatch:
                     # couldn't determine the url of the post so pass on it
                     continue

--- a/djangocms_blog/sitemaps/__init__.py
+++ b/djangocms_blog/sitemaps/__init__.py
@@ -3,7 +3,10 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 from cms.utils import get_language_list
 from django.contrib.sitemaps import Sitemap
-from django.urls.exceptions import NoReverseMatch
+try:
+    from django.urls.exceptions import NoReverseMatch
+except ImportError:
+    from django.conf.urls.exceptions import NoReverseMatch
 from parler.utils.context import smart_override
 
 from ..models import Post

--- a/djangocms_blog/sitemaps/__init__.py
+++ b/djangocms_blog/sitemaps/__init__.py
@@ -3,16 +3,17 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 from cms.utils import get_language_list
 from django.contrib.sitemaps import Sitemap
+from parler.utils.context import smart_override
+
+from ..models import Post
+from ..settings import get_setting
 
 try:
     from django.urls.exceptions import NoReverseMatch
 except ImportError:
     from django.core.urlresolvers import NoReverseMatch
 
-from parler.utils.context import smart_override
 
-from ..models import Post
-from ..settings import get_setting
 
 
 class BlogSitemap(Sitemap):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -6,6 +6,7 @@ import os.path
 from aldryn_apphooks_config.utils import get_app_instance
 from cms.api import add_plugin
 from cms.toolbar.items import ModalItem
+from cms.utils.apphook_reload import reload_urlconf
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
@@ -417,6 +418,22 @@ class ViewTest(BaseTest):
                 self.assertEqual(
                     sitemap.location(item), item.get_absolute_url()
                 )
+
+    def test_sitemap_with_unpublished(self):
+        posts = self.get_posts()
+        pages = self.get_pages()
+        sitemap = BlogSitemap()
+
+        self.assertEqual(len(sitemap.items()), 4)
+
+        # unpublish all the pages
+        for page in pages:
+            page.unpublish('en')
+            page.unpublish('it')
+
+        reload_urlconf()
+
+        self.assertEqual(len(sitemap.items()), 0)
 
     def test_sitemap_config(self):
         posts = self.get_posts()


### PR DESCRIPTION
Posts that are associated with an app config on a page that isn't published will
not have a url and will throw an exception which leads to a 500.

Fixes #368 