### PR TITLE
Require easy_thumbnails 2.4.1 and load easy_thumbnails_tags

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,6 +11,7 @@ Contributors
 ------------
 
 * alex
+* Bryan Marty
 * Carlo Ascani
 * Christoph Reimers
 * cluster-master

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -22,6 +22,7 @@ History
 * Improved admin filtering.
 * Added featured date to post.
 * Fixed issue with urls in sitemap if apphook is not published
+* Use the easy_thumbnails_tags template tag. Require easy_thumbnails >= 2.4.1
 
 
 *******************

--- a/djangocms_blog/templates/djangocms_blog/includes/blog_item.html
+++ b/djangocms_blog/templates/djangocms_blog/includes/blog_item.html
@@ -1,4 +1,4 @@
-{% load i18n thumbnail cms_tags %}
+{% load i18n easy_thumbnails_tags cms_tags %}
 
 <article id="post-{{ post.slug }}" class="post-item">
     <header>

--- a/djangocms_blog/templates/djangocms_blog/includes/blog_meta.html
+++ b/djangocms_blog/templates/djangocms_blog/includes/blog_meta.html
@@ -1,4 +1,4 @@
-{% load i18n thumbnail cms_tags %}
+{% load i18n easy_thumbnails_tags cms_tags %}
 
 <ul class="post-detail">
     {% if post.author %}

--- a/djangocms_blog/templates/djangocms_blog/plugins/authors.html
+++ b/djangocms_blog/templates/djangocms_blog/plugins/authors.html
@@ -1,4 +1,4 @@
-{% load i18n thumbnail %}{% spaceless %}
+{% load i18n easy_thumbnails_tags %}{% spaceless %}
 <div class="plugin plugin-blog">
     <h3>{% trans "Authors" %}</h3>
     <ul class="blog-authors">

--- a/djangocms_blog/templates/djangocms_blog/post_detail.html
+++ b/djangocms_blog/templates/djangocms_blog/post_detail.html
@@ -1,5 +1,5 @@
 {% extends "djangocms_blog/base.html" %}
-{% load i18n thumbnail cms_tags %}
+{% load i18n easy_thumbnails_tags cms_tags %}
 
 {% block canonical_url %}<link rel="canonical" href="{{ meta.url }}"/>{% endblock canonical_url %}
 {% block title %}{{ post.get_title }}{% endblock %}

--- a/djangocms_blog/templates/djangocms_blog/post_instant_article.html
+++ b/djangocms_blog/templates/djangocms_blog/post_instant_article.html
@@ -1,4 +1,4 @@
-{% load thumbnail cms_tags %}
+{% load easy_thumbnails_tags cms_tags %}
 <!doctype html>
 <html lang="{{ post.get_current_language }}" prefix="op: http://media.facebook.com/op#">
   <head>

--- a/djangocms_blog/templates/djangocms_blog/post_list.html
+++ b/djangocms_blog/templates/djangocms_blog/post_list.html
@@ -1,5 +1,5 @@
 {% extends "djangocms_blog/base.html" %}
-{% load i18n thumbnail %}{% spaceless %}
+{% load i18n easy_thumbnails_tags %}{% spaceless %}
 
 {% block canonical_url %}<link rel="canonical" href="{{ view.get_view_url }}"/>{% endblock canonical_url %}
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'django-taggit-autosuggest',
         'djangocms-text-ckeditor',
         'cmsplugin-filer>=1.0',
-        "easy-thumbnails>=2.4.1",
+        'easy-thumbnails>=2.4.1',
         'django-meta>=1.2',
         'django-meta-mixin>=0.3',
         'aldryn-apphooks-config>=0.2.6',

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         'django-taggit-autosuggest',
         'djangocms-text-ckeditor',
         'cmsplugin-filer>=1.0',
+        "easy-thumbnails>=2.4.1",
         'django-meta>=1.2',
         'django-meta-mixin>=0.3',
         'aldryn-apphooks-config>=0.2.6',


### PR DESCRIPTION
Fixes #377. Require easy_thumbnails 2.4.1 or greater and load the easy_thumbnails_tags template tag library.