### PR TITLE
Preset image and thumbnail sizes on a per app level.

### DIFF
--- a/djangocms_blog/admin.py
+++ b/djangocms_blog/admin.py
@@ -411,6 +411,7 @@ class BlogConfigAdmin(BaseAppHookConfig, TranslatableAdmin):
                 'fields': (
                     'config.paginate_by', 'config.url_patterns', 'config.template_prefix',
                     'config.menu_structure', 'config.menu_empty_categories',
+                    ('config.default_image_full', 'config.default_image_thumbnail'),
                 ),
                 'classes': ('collapse',)
             }),

--- a/djangocms_blog/admin.py
+++ b/djangocms_blog/admin.py
@@ -16,8 +16,7 @@ from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.utils import timezone
 from django.utils.six import callable, text_type
-from django.utils.translation import get_language_from_request, ungettext as __, ugettext_lazy as _
-
+from django.utils.translation import get_language_from_request, ugettext_lazy as _, ungettext as __
 from parler.admin import TranslatableAdmin
 
 from .cms_appconfig import BlogConfig

--- a/djangocms_blog/admin.py
+++ b/djangocms_blog/admin.py
@@ -16,7 +16,7 @@ from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.utils import timezone
 from django.utils.six import callable, text_type
-from django.utils.translation import get_language_from_request, ugettext_lazy as _, ungettext as __
+from django.utils.translation import get_language_from_request, ungettext as __, ugettext_lazy as _
 
 from parler.admin import TranslatableAdmin
 

--- a/djangocms_blog/cms_appconfig.py
+++ b/djangocms_blog/cms_appconfig.py
@@ -45,14 +45,14 @@ class BlogConfigForm(AppDataForm):
         label=_('Default size of full images'),
         queryset=ThumbnailOption.objects.all(),
         required=False,
-        help_text=_('If left  empty the image size will have to be set for '
+        help_text=_('If left empty the image size will have to be set for '
                     'every newly created post.'),
     )
     default_image_thumbnail = forms.ModelChoiceField(
         label=_('Default size of thumbnail images'),
         queryset=ThumbnailOption.objects.all(),
         required=False,
-        help_text=_('If left  empty the thumbnail image size will have to be '
+        help_text=_('If left empty the thumbnail image size will have to be '
                     'set for every newly created post.'),
     )
     url_patterns = forms.ChoiceField(

--- a/djangocms_blog/cms_appconfig.py
+++ b/djangocms_blog/cms_appconfig.py
@@ -11,6 +11,11 @@ from parler.models import TranslatableModel, TranslatedFields
 
 from .settings import MENU_TYPE_COMPLETE, get_setting
 
+try:  # pragma: no cover
+    from cmsplugin_filer_image.models import ThumbnailOption  # NOQA
+except ImportError:  # pragma: no cover
+    from filer.models import ThumbnailOption  # NOQA
+
 
 class BlogConfig(TranslatableModel, AppHookConfig):
     """
@@ -35,6 +40,20 @@ class BlogConfigForm(AppDataForm):
     default_published = forms.BooleanField(
         label=_('Post published by default'), required=False,
         initial=get_setting('DEFAULT_PUBLISHED')
+    )
+    default_image_full = forms.ModelChoiceField(
+        label=_('Default size of full images'),
+        queryset=ThumbnailOption.objects.all(),
+        required=False,
+        help_text=_('If left  empty the image size will have to be set for '
+                    'every newly created post.'),
+    )
+    default_image_thumbnail = forms.ModelChoiceField(
+        label=_('Default size of thumbnail images'),
+        queryset=ThumbnailOption.objects.all(),
+        required=False,
+        help_text=_('If left  empty the thumbnail image size will have to be '
+                    'set for every newly created post.'),
     )
     url_patterns = forms.ChoiceField(
         label=_('Permalink structure'), required=False,

--- a/djangocms_blog/forms.py
+++ b/djangocms_blog/forms.py
@@ -69,3 +69,13 @@ class PostAdminForm(TranslatableModelForm):
             # Don't allow app_configs to be added here. The correct way to add an
             # apphook-config is to create an apphook on a cms Page.
             self.fields['app_config'].widget.can_add_related = False
+
+        if 'app_config' in self.data and self.data['app_config'] \
+                and not self.instance.id:  # Instance must not be saved (yet)
+            config = BlogConfig.objects.get(pk=int(self.data['app_config']))
+            if 'main_image_full' not in self.data or self.data['main_image_full'] == '':
+                default = config.app_data['config'].get('default_image_full')
+                self.data['main_image_full'] = str(default.id) if default else ''
+            if 'main_image_thumbnail' not in self.data or self.data['main_image_thumbnail'] == '':
+                default = config.app_data['config'].get('default_image_thumbnail')
+                self.data['main_image_thumbnail'] = str(default.id) if default else ''

--- a/djangocms_blog/forms.py
+++ b/djangocms_blog/forms.py
@@ -56,6 +56,7 @@ class PostAdminForm(TranslatableModelForm):
 
         qs = BlogCategory.objects
 
+        config = None
         if getattr(self.instance, 'app_config_id', None):
             qs = qs.namespace(self.instance.app_config.namespace)
         elif 'initial' in kwargs and 'app_config' in kwargs['initial']:
@@ -70,12 +71,9 @@ class PostAdminForm(TranslatableModelForm):
             # apphook-config is to create an apphook on a cms Page.
             self.fields['app_config'].widget.can_add_related = False
 
-        if 'app_config' in self.data and self.data['app_config'] \
-                and not self.instance.id:  # Instance must not be saved (yet)
-            config = BlogConfig.objects.get(pk=int(self.data['app_config']))
-            if 'main_image_full' not in self.data or self.data['main_image_full'] == '':
-                default = config.app_data['config'].get('default_image_full')
-                self.data['main_image_full'] = str(default.id) if default else ''
-            if 'main_image_thumbnail' not in self.data or self.data['main_image_thumbnail'] == '':
-                default = config.app_data['config'].get('default_image_thumbnail')
-                self.data['main_image_thumbnail'] = str(default.id) if default else ''
+        if config:
+            self.initial['main_image_full'] = \
+                config.app_data['config'].get('default_image_full')
+            self.initial['main_image_thumbnail'] = \
+                config.app_data['config'].get('default_image_thumbnail')
+

--- a/djangocms_blog/forms.py
+++ b/djangocms_blog/forms.py
@@ -76,4 +76,3 @@ class PostAdminForm(TranslatableModelForm):
                 config.app_data['config'].get('default_image_full')
             self.initial['main_image_thumbnail'] = \
                 config.app_data['config'].get('default_image_thumbnail')
-


### PR DESCRIPTION
This is a first shot for #357. Comments appreciated. Adds strings to be localised.

To consistently set image sizes for preview and full size images for each post and avoid editors to have to set them coherently for each post this PR adds default sizes in the app config.
