### PR TITLE
Disable menu subitems & fix wrong plugin url

### DIFF
--- a/djangocms_blog/cms_menus.py
+++ b/djangocms_blog/cms_menus.py
@@ -12,7 +12,7 @@ from menus.menu_pool import menu_pool
 
 from .cms_appconfig import BlogConfig
 from .models import BlogCategory, Post
-from .settings import MENU_TYPE_CATEGORIES, MENU_TYPE_COMPLETE, MENU_TYPE_POSTS, get_setting
+from .settings import MENU_TYPE_NONE, MENU_TYPE_CATEGORIES, MENU_TYPE_COMPLETE, MENU_TYPE_POSTS, get_setting
 
 
 class BlogCategoryMenu(CMSAttachMenu):
@@ -59,6 +59,8 @@ class BlogCategoryMenu(CMSAttachMenu):
             categories_menu = True
         if config and config.menu_structure in (MENU_TYPE_COMPLETE, MENU_TYPE_POSTS):
             posts_menu = True
+        if config and config.menu_structure in (MENU_TYPE_NONE, ):
+            return nodes
 
         used_categories = []
         if posts_menu:

--- a/djangocms_blog/cms_menus.py
+++ b/djangocms_blog/cms_menus.py
@@ -12,8 +12,9 @@ from menus.menu_pool import menu_pool
 
 from .cms_appconfig import BlogConfig
 from .models import BlogCategory, Post
-from .settings import (MENU_TYPE_NONE, MENU_TYPE_CATEGORIES,
-                       MENU_TYPE_COMPLETE, MENU_TYPE_POSTS, get_setting)
+from .settings import (
+    MENU_TYPE_CATEGORIES, MENU_TYPE_COMPLETE, MENU_TYPE_NONE, MENU_TYPE_POSTS, get_setting,
+)
 
 
 class BlogCategoryMenu(CMSAttachMenu):

--- a/djangocms_blog/cms_menus.py
+++ b/djangocms_blog/cms_menus.py
@@ -12,7 +12,8 @@ from menus.menu_pool import menu_pool
 
 from .cms_appconfig import BlogConfig
 from .models import BlogCategory, Post
-from .settings import MENU_TYPE_NONE, MENU_TYPE_CATEGORIES, MENU_TYPE_COMPLETE, MENU_TYPE_POSTS, get_setting
+from .settings import (MENU_TYPE_NONE, MENU_TYPE_CATEGORIES,
+                       MENU_TYPE_COMPLETE, MENU_TYPE_POSTS, get_setting)
 
 
 class BlogCategoryMenu(CMSAttachMenu):

--- a/djangocms_blog/templates/djangocms_blog/plugins/categories.html
+++ b/djangocms_blog/templates/djangocms_blog/plugins/categories.html
@@ -3,7 +3,7 @@
     <h3>{% trans "Categories" %}</h3>
     <ul class="blog-categories">
         {% for category in categories %}
-            <li><a href="{% url 'djangocms_blog:posts-category' category=category.slug %}" class="blog-categories-{{ category.count }}">
+            <li><a href="{{ category.get_absolute_url }}" class="blog-categories-{{ category.count }}">
                 {{ category.name }}
                 <span>(
                     {% if category.count > 0 %}


### PR DESCRIPTION
1) Django cms blog app is configured to use BlogCategoryMenu by default and can't be disabled. In case that you don't want to show submenus, you can't disable the default menu even when you remove the menu from the CMS page config. 

2) Categories plugin template refers to category urls without honouring the app config. If you have more than one blog config (blog & news) the category plugin always resolves urls that points to the blog app config. It's an option to override the blog templates and fix it, but if you use the default template, you'll surprised why it always resolves the same app.

