### PR TITLE
Fix error in category filtering when loading the form via POST

### DIFF
--- a/djangocms_blog/cms_wizards.py
+++ b/djangocms_blog/cms_wizards.py
@@ -10,13 +10,13 @@ from django import forms
 from django.conf import settings
 from django.utils.text import slugify
 from django.utils.translation import ugettext_lazy as _
-from parler.forms import TranslatableModelForm
 
 from .cms_appconfig import BlogConfig
+from .forms import PostAdminFormBase
 from .models import Post
 
 
-class PostWizardForm(TranslatableModelForm):
+class PostWizardForm(PostAdminFormBase):
     default_appconfig = None
 
     def __init__(self, *args, **kwargs):
@@ -31,6 +31,8 @@ class PostWizardForm(TranslatableModelForm):
             choices=self.fields['app_config'].widget.choices,
         )
         self.fields['app_config'].widget.attrs['disabled'] = True
+        if 'categories' in self.fields:
+            self.fields['categories'].queryset = self.available_categories
 
     class Meta:
         model = Post

--- a/tests/test_wizards.py
+++ b/tests/test_wizards.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import sys
 
+from djangocms_blog.models import BlogCategory
+
 from .base import BaseTest
 
 
@@ -41,6 +43,12 @@ class WizardTest(BaseTest):
         from djangocms_blog.models import Post
         self.get_pages()
 
+        cat_1 = BlogCategory.objects.create(name='category 1 - blog 1', app_config=self.app_config_1)
+        cat_2 = BlogCategory.objects.create(name='category 1 - blog 2', app_config=self.app_config_2)
+        cats = {
+            self.app_config_1.pk: cat_1,
+            self.app_config_2.pk: cat_2,
+        }
         with current_user(self.user_staff):
             wizs = [entry for entry in wizard_pool.get_entries() if entry.model == Post]
             for index, wiz in enumerate(wizs):
@@ -52,7 +60,7 @@ class WizardTest(BaseTest):
                 form = wiz.form(data={
                     '1-title': 'title{0}'.format(index),
                     '1-abstract': 'abstract{0}'.format(index),
-                    '1-categories': [self.category_1.pk],
+                    '1-categories': [cats[app_config].pk],
                 }, prefix=1)
                 self.assertEqual(form.default_appconfig, app_config)
                 self.assertTrue(form.is_valid())
@@ -66,13 +74,33 @@ class WizardTest(BaseTest):
                     form = wiz.form(data={
                         '1-title': 'title-2{0}'.format(index),
                         '1-abstract': 'abstract-2{0}'.format(index),
-                        '1-categories': [self.category_1.pk],
+                        '1-categories': [cats[app_config].pk],
                     }, prefix=1)
                     self.assertEqual(form.default_appconfig, app_config)
                     self.assertTrue(form.is_valid())
                     self.assertEqual(form.cleaned_data['app_config'].pk, app_config)
                     instance = form.save()
                     self.assertEqual(instance.author, self.user_normal)
+
+    def test_wizard_init_categories_check(self):
+        from cms.utils.permissions import current_user
+        from cms.wizards.wizard_pool import wizard_pool
+        from djangocms_blog.models import Post
+        self.get_pages()
+
+        with current_user(self.user_staff):
+            wiz = None
+            for wiz in wizard_pool.get_entries():
+                if wiz.model == Post and wiz.title == 'New Article':
+                    break
+            form = wiz.form(data={
+                '1-title': 'title article',
+                '1-abstract': 'abstract article',
+                '1-categories': [self.category_1.pk],
+            }, prefix=1)
+            self.assertEqual(form.default_appconfig, self.app_config_2.pk)
+            self.assertFalse(form.is_valid())
+            self.assertTrue('categories' in form.errors.keys())
 
     def test_wizard_import(self):
         # The following import should not fail in any django CMS version


### PR DESCRIPTION
When loading the form via POST (for example if a form fails validation) the app_config wasn't used to filter categories in the category and post form