### PR TITLE
Fix wizard in Django 1.11

### DIFF
--- a/djangocms_blog/cms_wizards.py
+++ b/djangocms_blog/cms_wizards.py
@@ -29,7 +29,9 @@ class PostWizardForm(PostAdminFormBase):
             kwargs['initial'] = {}
         kwargs['initial']['app_config'] = self.default_appconfig
         if 'data' in kwargs and kwargs['data'] is not None:
-            kwargs['data']['1-app_config'] = self.default_appconfig
+            data = kwargs['data'].copy()
+            data['1-app_config'] = self.default_appconfig
+            kwargs['data'] = data
         super(PostWizardForm, self).__init__(*args, **kwargs)
         self.fields['app_config'].widget = forms.Select(
             attrs=self.fields['app_config'].widget.attrs,

--- a/tests/test_wizards.py
+++ b/tests/test_wizards.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import sys
 
+from django.http import QueryDict
+
 from djangocms_blog.models import BlogCategory
 
 from .base import BaseTest
@@ -25,6 +27,12 @@ class WizardTest(BaseTest):
             # Not in django CMS 3.2+, no cleanup needed
             pass
         super(WizardTest, self).setUp()
+
+    def get_querydict(self, source):
+        tmp = QueryDict(mutable=True)
+        tmp.update(source)
+        tmp._mutable = False
+        return tmp
 
     def test_wizard(self):
         """
@@ -57,11 +65,11 @@ class WizardTest(BaseTest):
                 self.assertTrue(form.initial.get('app_config', False), app_config)
                 self.assertTrue(form.fields['app_config'].widget.attrs['disabled'])
 
-                form = wiz.form(data={
+                form = wiz.form(data=self.get_querydict({
                     '1-title': 'title{0}'.format(index),
                     '1-abstract': 'abstract{0}'.format(index),
-                    '1-categories': [cats[app_config].pk],
-                }, prefix=1)
+                    '1-categories': cats[app_config].pk,
+                }), prefix=1)
                 self.assertEqual(form.default_appconfig, app_config)
                 self.assertTrue(form.is_valid())
                 self.assertEqual(form.cleaned_data['app_config'].pk, app_config)
@@ -71,11 +79,11 @@ class WizardTest(BaseTest):
             with self.settings(BLOG_AUTHOR_DEFAULT='normal'):
                 for index, wiz in enumerate(wizs):
                     app_config = self.app_config_1.pk if wiz.title == 'New Blog' else self.app_config_2.pk
-                    form = wiz.form(data={
+                    form = wiz.form(data=self.get_querydict({
                         '1-title': 'title-2{0}'.format(index),
                         '1-abstract': 'abstract-2{0}'.format(index),
-                        '1-categories': [cats[app_config].pk],
-                    }, prefix=1)
+                        '1-categories': cats[app_config].pk,
+                    }), prefix=1)
                     self.assertEqual(form.default_appconfig, app_config)
                     self.assertTrue(form.is_valid())
                     self.assertEqual(form.cleaned_data['app_config'].pk, app_config)
@@ -94,21 +102,21 @@ class WizardTest(BaseTest):
             for wiz in wizard_pool.get_entries():
                 if wiz.model == Post and wiz.title == 'New Blog':
                     break
-            form = wiz.form(data={
+            form = wiz.form(data=self.get_querydict({
                 '1-title': 'title article',
                 '1-abstract': 'abstract article',
-                '1-categories': [self.category_1.pk],
-            }, prefix=1)
+                '1-categories': self.category_1.pk,
+            }), prefix=1)
             self.assertEqual(form.default_appconfig, self.app_config_1.pk)
             self.assertTrue(form.is_valid())
             instance1 = form.save()
             self.assertEqual(instance1.slug, 'title-article')
 
-            form = wiz.form(data={
+            form = wiz.form(data=self.get_querydict({
                 '1-title': 'title article',
                 '1-abstract': 'abstract article',
-                '1-categories': [self.category_1.pk],
-            }, prefix=1)
+                '1-categories': self.category_1.pk,
+            }), prefix=1)
             self.assertEqual(form.default_appconfig, self.app_config_1.pk)
             self.assertTrue(form.is_valid())
             instance2 = form.save()
@@ -117,11 +125,11 @@ class WizardTest(BaseTest):
             for wiz in wizard_pool.get_entries():
                 if wiz.model == Post and wiz.title == 'New Article':
                     break
-            form = wiz.form(data={
+            form = wiz.form(data=self.get_querydict({
                 '1-title': 'title article',
                 '1-abstract': 'abstract article',
-                '1-categories': [cat_2.pk],
-            }, prefix=1)
+                '1-categories': cat_2.pk,
+            }), prefix=1)
             self.assertEqual(form.default_appconfig, self.app_config_2.pk)
             self.assertTrue(form.is_valid())
             instance3 = form.save()
@@ -138,11 +146,11 @@ class WizardTest(BaseTest):
             for wiz in wizard_pool.get_entries():
                 if wiz.model == Post and wiz.title == 'New Article':
                     break
-            form = wiz.form(data={
+            form = wiz.form(data=self.get_querydict({
                 '1-title': 'title article',
                 '1-abstract': 'abstract article',
-                '1-categories': [self.category_1.pk],
-            }, prefix=1)
+                '1-categories': self.category_1.pk,
+            }), prefix=1)
             self.assertEqual(form.default_appconfig, self.app_config_2.pk)
             self.assertFalse(form.is_valid())
             self.assertTrue('categories' in form.errors.keys())


### PR DESCRIPTION
Use a mutable copy of form data when injecting the apphook config in the wizard
Fix #435 