### PR TITLE
Feature/customisable ckeditor

### DIFF
--- a/djangocms_blog/models.py
+++ b/djangocms_blog/models.py
@@ -227,7 +227,8 @@ class Post(KnockerModel, BlogMetaMixin, TranslatableModel):
         title=models.CharField(_('title'), max_length=767),
         slug=AutoSlugField(_('slug'), max_length=767, blank=True,
                            db_index=True, allow_unicode=True),
-        abstract=HTMLField(_('abstract'), blank=True, default=''),
+        abstract=HTMLField(_('abstract'), blank=True, default='',
+                           configuration='BLOG_ABSTRACT_CKEDITOR'),
         meta_description=models.TextField(verbose_name=_('post meta description'),
                                           blank=True, default=''),
         meta_keywords=models.TextField(verbose_name=_('post meta keywords'),
@@ -236,7 +237,8 @@ class Post(KnockerModel, BlogMetaMixin, TranslatableModel):
                                     help_text=_('used in title tag and social sharing'),
                                     max_length=2000,
                                     blank=True, default=''),
-        post_text=HTMLField(_('text'), default='', blank=True),
+        post_text=HTMLField(_('text'), default='', blank=True,
+                            configuration='BLOG_POST_TEXT_CKEDITOR'),
         meta={'unique_together': (('language_code', 'slug'),)}
     )
     content = PlaceholderField('post_content', related_name='post_content')

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -97,7 +97,8 @@ Global Settings
 * BLOG_PLUGIN_TEMPLATE_FOLDERS: (Sub-)folder from which the plugin templates are loaded. The default folder is ``plugins``. It goes into the ``djangocms_blog`` template folder (or, if set, the folder named in the app hook). This allows, e.g., different templates for showing a post list as tables, columns, ... . New templates have the same names as the standard templates in the ``plugins`` folder (``latest_entries.html``, ``authors.html``, ``tags.html``, ``categories.html``, ``archive.html``). Default behavior corresponds to this setting being ``( ("plugins", _("Default template") )``. To add new templates add to this setting, e.g., ``('timeline', _('Vertical timeline') )``.
 * BLOG_META_DESCRIPTION_LENGTH: Maximum length for the Meta description field (default: ``320``)
 * BLOG_META_TITLE_LENGTH: Maximum length for the Meta title field (default: ``70``)
-
+* BLOG_ABSTRACT_CKEDITOR: Configuration for the CKEditor of the abstract field (as per https://github.com/divio/djangocms-text-ckeditor/#customizing-htmlfield-editor)
+* BLOG_POST_TEXT_CKEDITOR: Configuration for the CKEditor of the post content field
 
 ******************
 Read-only settings


### PR DESCRIPTION
Added ability to include CKEditor settings for the blog abstract and post contents (as per https://github.com/divio/djangocms-text-ckeditor/#customizing-htmlfield-editor). Discussed at https://github.com/nephila/djangocms-blog/issues/446