### PR TITLE
Fix __str__ for Post and BlogCategory w/ no translation

### DIFF
--- a/djangocms_blog/models.py
+++ b/djangocms_blog/models.py
@@ -18,7 +18,7 @@ from django.utils import timezone
 from django.utils.encoding import force_bytes, force_text, python_2_unicode_compatible
 from django.utils.functional import cached_property
 from django.utils.html import escape, strip_tags
-from django.utils.translation import get_language, ugettext_lazy as _, ugettext
+from django.utils.translation import get_language, ugettext, ugettext_lazy as _
 from djangocms_text_ckeditor.fields import HTMLField
 from filer.fields.image import FilerImageField
 from meta.models import ModelMeta

--- a/djangocms_blog/models.py
+++ b/djangocms_blog/models.py
@@ -18,7 +18,7 @@ from django.utils import timezone
 from django.utils.encoding import force_bytes, force_text, python_2_unicode_compatible
 from django.utils.functional import cached_property
 from django.utils.html import escape, strip_tags
-from django.utils.translation import get_language, ugettext_lazy as _
+from django.utils.translation import get_language, ugettext_lazy as _, ugettext
 from djangocms_text_ckeditor.fields import HTMLField
 from filer.fields.image import FilerImageField
 from meta.models import ModelMeta
@@ -164,7 +164,7 @@ class BlogCategory(BlogMetaMixin, TranslatableModel):
         )
 
     def __str__(self):
-        return self.safe_translation_getter('name', any_language=True)
+        return self.safe_translation_getter('name', any_language=True, default=ugettext('BlogCategory (no translation)'))
 
     def save(self, *args, **kwargs):
         super(BlogCategory, self).save(*args, **kwargs)
@@ -287,7 +287,7 @@ class Post(KnockerModel, BlogMetaMixin, TranslatableModel):
         get_latest_by = 'date_published'
 
     def __str__(self):
-        return self.safe_translation_getter('title', any_language=True)
+        return self.safe_translation_getter('title', any_language=True, default=ugettext('Post (no translation)'))
 
     @property
     def guid(self, language=None):

--- a/djangocms_blog/models.py
+++ b/djangocms_blog/models.py
@@ -164,7 +164,8 @@ class BlogCategory(BlogMetaMixin, TranslatableModel):
         )
 
     def __str__(self):
-        return self.safe_translation_getter('name', any_language=True, default=ugettext('BlogCategory (no translation)'))
+        default = ugettext('BlogCategory (no translation)')
+        return self.safe_translation_getter('name', any_language=True, default=default)
 
     def save(self, *args, **kwargs):
         super(BlogCategory, self).save(*args, **kwargs)
@@ -287,7 +288,8 @@ class Post(KnockerModel, BlogMetaMixin, TranslatableModel):
         get_latest_by = 'date_published'
 
     def __str__(self):
-        return self.safe_translation_getter('title', any_language=True, default=ugettext('Post (no translation)'))
+        default = ugettext('Post (no translation)')
+        return self.safe_translation_getter('title', any_language=True, default=default)
 
     @property
     def guid(self, language=None):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1147,7 +1147,7 @@ class ModelsTest2(BaseTest):
         self.assertEqual(force_text(plugin.__str__()), 'generic blog plugin')
 
         no_translation_post = Post()
-        no_translation_default_title = ''
+        no_translation_default_title = 'Post (no translation)'
         self.assertEqual(force_text(no_translation_post), no_translation_default_title)
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1146,6 +1146,10 @@ class ModelsTest2(BaseTest):
         )
         self.assertEqual(force_text(plugin.__str__()), 'generic blog plugin')
 
+        no_translation_post = Post()
+        no_translation_default_title = ''
+        self.assertEqual(force_text(no_translation_post), no_translation_default_title)
+
 
 class KnockerTest(BaseTest):
 


### PR DESCRIPTION
Fix string representation for `Post`s and `BlogCategory`s without translation instance related.