### PR TITLE
Default plugin templates to djangocms_blog base versions.

### DIFF
--- a/djangocms_blog/cms_plugins.py
+++ b/djangocms_blog/cms_plugins.py
@@ -7,6 +7,7 @@ from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 from django.contrib.sites.shortcuts import get_current_site
 from django.db import models
+from django.template.loader import select_template
 
 from .forms import LatestEntriesForm
 from .models import AuthorEntriesPlugin, BlogCategory, GenericBlogPlugin, LatestPostsPlugin, Post
@@ -17,15 +18,18 @@ class BlogPlugin(CMSPluginBase):
     module = get_setting('PLUGIN_MODULE_NAME')
 
     def get_render_template(self, context, instance, placeholder):
-        if instance.app_config and instance.app_config.template_prefix:
-            return os.path.join(instance.app_config.template_prefix,
-                                instance.template_folder,
-                                self.base_render_template)
-        else:
-            return os.path.join('djangocms_blog',
-                                instance.template_folder,
-                                self.base_render_template)
 
+        templates = [os.path.join('djangocms_blog',
+                                  instance.template_folder,
+                                  self.base_render_template)]
+
+        if instance.app_config and instance.app_config.template_prefix:
+            templates.insert(0, os.path.join(instance.app_config.template_prefix,
+                                             instance.template_folder,
+                                             self.base_render_template))
+
+        selected = select_template(templates)
+        return selected.template.name
 
 class BlogLatestEntriesPlugin(BlogPlugin):
     """


### PR DESCRIPTION
If a template_prefix has been set in the blog app_config, any
plugin will cause a TemplateDoesNotExist exception unless the
entire template directory is copied.  You will see:

Exception Type: TemplateDoesNotExist at /about/jobs/
Exception Value: djangocms_blog/jobs/plugins/latest_entries.html

This commit refactors get_rendor_template in BlogPlugin to use the
django loader select_template method to first look for an override
then default to the base version of the plugin.