### PR TITLE
Solving issue #297

### DIFF
--- a/djangocms_blog/forms.py
+++ b/djangocms_blog/forms.py
@@ -116,6 +116,10 @@ class PostAdminForm(PostAdminFormBase):
         ]
         super(PostAdminForm, self).__init__(*args, **kwargs)
         if 'categories' in self.fields:
+            if self.app_config:
+                if self.app_config.url_patterns:
+                    if self.app_config.url_patterns == 'category':
+                        self.fields['categories'].required = True
             self.fields['categories'].queryset = self.available_categories
 
         if 'app_config' in self.fields:


### PR DESCRIPTION
If `self.app_config.url_patterns` setting is 'category', categories field is set as required.