### PR TITLE
django-meta facebook image size

### DIFF
--- a/djangocms_blog/models.py
+++ b/djangocms_blog/models.py
@@ -265,6 +265,8 @@ class Post(KnockerModel, BlogMetaMixin, TranslatableModel):
         'gplus_description': 'get_description',
         'locale': 'get_locale',
         'image': 'get_image_full_url',
+        'image_width': 'get_image_width',
+        'image_height': 'get_image_height',
         'object_type': 'get_meta_attribute',
         'og_type': 'get_meta_attribute',
         'og_app_id': 'get_meta_attribute',
@@ -379,6 +381,14 @@ class Post(KnockerModel, BlogMetaMixin, TranslatableModel):
         if self.main_image:
             return self.build_absolute_uri(self.main_image.url)
         return ''
+
+    def get_image_width(self):
+        if self.main_image:
+            return self.main_image.width
+
+    def get_image_height(self):
+        if self.main_image:
+            return self.main_image.height
 
     def get_tags(self):
         """

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -811,6 +811,8 @@ class ModelsTest(BaseTest):
         self.assertEqual(meta_en.gplus_author, 'RandomJoe')
         self.assertEqual(meta_en.gplus_type, 'Blog')
         self.assertEqual(meta_en.og_type, 'Article')
+        self.assertEqual(meta_en.image_width, post.main_image.width)
+        self.assertEqual(meta_en.image_height, post.main_image.height)
         self.assertEqual(meta_en.facebook_app_id, None)
         post.set_current_language('it')
         meta_it = post.as_meta()


### PR DESCRIPTION
Add image width and image height to page meta properties for better facebook sharing user experience.
According to Facebook documentation
https://developers.facebook.com/docs/sharing/best-practices/?locale=en_US#precaching

Support of image dimensions were added by this pull request
https://github.com/nephila/django-meta/pull/91

It requires django-meta==1.5.2 to be installed. Backward compatible with previous versions of django-meta
