### PR TITLE
 Empty menu cache when deleting blogconfig instances 

### DIFF
--- a/djangocms_blog/cms_menus.py
+++ b/djangocms_blog/cms_menus.py
@@ -191,3 +191,4 @@ def clear_menu_cache(**kwargs):
 
 post_save.connect(clear_menu_cache, sender=BlogCategory)
 post_delete.connect(clear_menu_cache, sender=BlogCategory)
+post_delete.connect(clear_menu_cache, sender=BlogConfig)


### PR DESCRIPTION
Delete django / menu cache when a blogconfig is deleted