### PR TITLE
Use menu_empty_categories config for BlogCategoryPlugin

### DIFF
--- a/cms_helper.py
+++ b/cms_helper.py
@@ -150,3 +150,7 @@ def setup():
 
 if __name__ == '__main__':
     run()
+
+if __name__ == 'cms_helper':
+    # this is needed to run cms_helper in pycharm
+    setup()

--- a/djangocms_blog/cms_plugins.py
+++ b/djangocms_blog/cms_plugins.py
@@ -112,7 +112,10 @@ class BlogCategoryPlugin(BlogPlugin):
             qs = qs.filter(
                 models.Q(blog_posts__sites__isnull=True) | models.Q(blog_posts__sites=site.pk)
             )
-        context['categories'] = qs.distinct()
+        categories = qs.distinct()
+        if instance.app_config and not instance.app_config.menu_empty_categories:
+            categories = qs.filter(blog_posts__isnull=False).distinct()
+        context['categories'] = categories
         return context
 
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -289,3 +289,16 @@ class PluginTest2(BaseTest):
         with self.settings(SITE_ID=2):
             context = plugin_class.render(context, plugin, ph)
             self.assertEqual(list(context['categories']), [self.category_1, new_category])
+
+        empty_category = BlogCategory.objects.create(
+            name='empty 2', app_config=self.app_config_1
+        )
+        self.app_config_1.app_data.config.menu_empty_categories = False
+        self.app_config_1.save()
+        context = plugin_class.render(context, plugin, ph)
+        self.assertEqual(list(context['categories']), [self.category_1, new_category])
+
+        self.app_config_1.app_data.config.menu_empty_categories = True
+        self.app_config_1.save()
+        context = plugin_class.render(context, plugin, ph)
+        self.assertEqual(list(context['categories']), [self.category_1, new_category, empty_category])


### PR DESCRIPTION
This aligns the behavior of `BlogCategoryPlugin` with the menu, as most editors don't care about the difference between the categories pulled by the menu and the ones from the plugin: if `menu_empty_categories` is set to `False` in the related `BlogConfig`, categories without posts are hidden in the `BlogCategoryPlugin`