### PR TITLE
Fixed dependency on django-parler

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        'django-parler>=1.9',
+        'django-parler>=2.0',
         'django-cms>=3.5',
         'django-taggit>=0.20,<1.2',
         'django-filer>=1.4',


### PR DESCRIPTION
djangocms-blog now requires django-parler>=2.0 as there are added new fields
which are used in migrations. Those fields aren't available in previous
versions.