### PR TITLE
Remove cmsplugin_filer from installation docs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,12 @@ History
 =======
 
 *******************
+1.0.1 (unreleased)
+*******************
+
+* Remove cmsplugin_filer from installation docs
+
+*******************
 1.0.0 (2019-11-04)
 *******************
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -22,7 +22,6 @@ Add ``djangocms_blog`` and its dependencies to INSTALLED_APPS:
         'filer',
         'easy_thumbnails',
         'aldryn_apphooks_config',
-        'cmsplugin_filer_image',
         'parler',
         'taggit',
         'taggit_autosuggest',


### PR DESCRIPTION
cmsplugin-filer is no longer supported

Fix #518
Fix #522 