### PR TITLE
Fix 'setup.py develop' installation by preventing the installation of Django 3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
+        'django<3.0',
         'django-parler>=2.0',
         'django-cms>=3.5',
         'django-taggit>=0.20,<1.2',


### PR DESCRIPTION
### Bug:

When I run `python setup.py`, I am confronted with an error:
```
error: Django 3.0 is installed but django<3.0,>=1.11 is required by {'django-cms', 'django-filer'}
```
### Cause:

`install_requires` in `setup.py` does not prevent Django 3.0 to be installed (and Django 3.0 is now the default installed version):

https://github.com/nephila/djangocms-blog/blob/b10cbda6528527b8e25813b41f890c604ada8330/setup.py#L29-L44

### Solution:

No real solution since I don't know if `django-cms` & `django-filer` are compatible with Django 3.0.

But adding `'django<3.0',` in `install_requires` seems to fix the problem for now (`setup.py develop` will install Django 2.2.6).