### PR TITLE
Author Blog Articles plugin improvement

### DIFF
--- a/djangocms_blog/models.py
+++ b/djangocms_blog/models.py
@@ -562,7 +562,10 @@ class AuthorEntriesPlugin(BasePostPlugin):
                 qs = qs.published(current_site=False)
             count = qs.count()
             if count:
+                # total nb of articles
                 author.count = count
+                # "the number of author articles to be displayed"
+                author.posts = qs[:self.latest_posts]
         return authors
 
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -26,8 +26,8 @@ policies.
 
 These include:
 
-* `guidelines and policies
-  <http://docs.django-cms.org/en/latest/contributing/contributing.html>`_ for contributing
+* `development policies
+  <http://docs.django-cms.org/en/latest/contributing/development-policies.html>`_ for contributing
   to the project, including standards for code and documentation
 * standards for `managing the project's development
   <http://docs.django-cms.org/en/latest/contributing/management.html>`_


### PR DESCRIPTION
*tl;dr: We want a "**get the N latest posts written by this author**" feature.*

## Context
Currently, here's the look of the "Author Blog Articles" plugin:

![image](https://user-images.githubusercontent.com/45763865/70983105-765b7d00-20b8-11ea-9742-2a7f40fce494.png)

There's two problems here:
1. Each author is displayed once for each article he or she has published.
  https://github.com/nephila/djangocms-blog/blob/b10cbda6528527b8e25813b41f890c604ada8330/djangocms_blog/models.py#L535
  *This is a well-known, [old django bug](https://code.djangoproject.com/ticket/11707).*
2. There is a "*Articles*" input. "*The number of author articles to be displayed*" is not really used (*but it could be*).

![image](https://user-images.githubusercontent.com/45763865/70983083-6ba0e800-20b8-11ea-89b4-48874326b226.png)

See? We have set the value "Articles" to 1, but all the plugin does is to display the first and last names of the selected authors, as well as the number of blog posts they have written.

## What is done?
*We have looked in the code of djangocms-blog.*

Here we are in `models.py`:

![image](https://user-images.githubusercontent.com/45763865/70983723-7f991980-20b9-11ea-9d8e-334566be49fb.png)

There is two things to notice here:
1. `AuthorEntriesPlugin` have a `get_posts` function (*but that function is not used*),
2. We are getting a queryset of the blog posts posted by each author selected in the plugin (with `djangocms_blog_post_author`, a [`RelatedManager`](https://docs.djangoproject.com/en/3.0/ref/models/relations/#django.db.models.fields.related.RelatedManager)), we count them, and then we add this number to the [context](https://user-images.githubusercontent.com/45763865/70983935-d9014880-20b9-11ea-8c14-4954e05e3b70.png) (in `cms_plugins.py`) so the template can display this number:

![image](https://user-images.githubusercontent.com/45763865/70984345-9ab85900-20ba-11ea-942c-8a44e0a57866.png)

![image](https://user-images.githubusercontent.com/45763865/70984221-5fb62580-20ba-11ea-9fcf-91e14ac2903d.png)

## What we want?

We want to add the posts in the context in addition to the total number of articles posted (the `count`).
This can be done by slicing the queryset with `self.latest_posts` (the *Articles - number of author articles to be displayed* value), and adding this queryset to the `authors` 

![image](https://user-images.githubusercontent.com/45763865/70984571-04386780-20bb-11ea-91d6-14981a36b908.png)

## Results:

 * Here's a view of the blog used to test the feature:
  ![image](https://user-images.githubusercontent.com/45763865/70985671-c76d7000-20bc-11ea-869f-97da1a9e89cc.png)
 * Here's the updated template used to test the feature (*[link to a gist](https://gist.github.com/corentinbettiol/d4e028938918224ade665e44d5d43e4f)*):
  ![image](https://user-images.githubusercontent.com/45763865/70985717-dc4a0380-20bc-11ea-8cab-975c6a4f2496.png)
 * And here are the results:
  ![image](https://user-images.githubusercontent.com/45763865/70986023-68f4c180-20bd-11ea-8581-df04b32ab41b.png)
  ![image](https://user-images.githubusercontent.com/45763865/70986192-bc670f80-20bd-11ea-853a-d5f496681858.png)


