### PR TITLE
Add experimental support for django-app-enabler

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,4 @@ include CONTRIBUTING.rst
 include HISTORY.rst
 include LICENSE
 include README.rst
-recursive-include djangocms_blog *.html *.png *.gif *js *jpg *jpeg *svg *py *css *po *mo
+recursive-include djangocms_blog *.html *.png *.gif *js *jpg *jpeg *svg *py *css *po *mo *json

--- a/addon.json
+++ b/addon.json
@@ -1,14 +1,1 @@
-{
-    "package-name": "djangocms-blog",
-    "installed-apps": [
-        "filer",
-        "easy_thumbnails",
-        "aldryn_apphooks_config",
-        "parler",
-        "taggit",
-        "taggit_autosuggest",
-        "meta",
-        "djangocms_blog",
-        "sortedm2m"
-    ]
-}
+djangocms_blog/addon.json

--- a/djangocms_blog/addon.json
+++ b/djangocms_blog/addon.json
@@ -13,7 +13,10 @@
     ],
     "settings": {
         "META_SITE_PROTOCOL": "http",
-        "META_USE_SITES": true
+        "META_USE_SITES": true,
+        "META_USE_OG_PROPERTIES": true,
+        "META_USE_TWITTER_PROPERTIES": true,
+        "META_USE_GOOGLEPLUS_PROPERTIES": true
     },
     "urls": [
         "djangocms_blog.taggit_urls"

--- a/djangocms_blog/addon.json
+++ b/djangocms_blog/addon.json
@@ -1,0 +1,21 @@
+{
+    "package-name": "djangocms-blog",
+    "installed-apps": [
+        "filer",
+        "easy_thumbnails",
+        "aldryn_apphooks_config",
+        "parler",
+        "taggit",
+        "taggit_autosuggest",
+        "meta",
+        "djangocms_blog",
+        "sortedm2m"
+    ],
+    "settings": {
+        "META_SITE_PROTOCOL": "http",
+        "META_USE_SITES": true
+    },
+    "urls": [
+        "djangocms_blog.taggit_urls"
+    ]
+}


### PR DESCRIPTION
Reuse divio cloud addon.js file for django-app-enabler and move so that it will be shipped in the python package

**Experimental support** just to validate the whole concept

TODO (after merge and possibly release of this):

* [ ] Ship a usable version of django-app-enabler
* [ ] Add documentation (the app only needs to document the basics about how to use django-app-enabler)