### PR TITLE
Moved post slug to top of post admin form

### DIFF
--- a/djangocms_blog/admin.py
+++ b/djangocms_blog/admin.py
@@ -87,7 +87,7 @@ class PostAdmin(PlaceholderAdminMixin, FrontendEditableAdminMixin,
     _fieldsets = [
         (None, {
             'fields': [
-                ['title', 'subtitle', 'publish'],
+                ['title', 'subtitle', 'slug', 'publish'],
                 ['categories', 'app_config']
             ]
         }),
@@ -95,7 +95,7 @@ class PostAdmin(PlaceholderAdminMixin, FrontendEditableAdminMixin,
             'fields': [[]]
         }),
         (_('Info'), {
-            'fields': [['slug', 'tags'],
+            'fields': [['tags'],
                        ['date_published', 'date_published_end', 'date_featured'],
                        ['enable_comments']],
             'classes': ('collapse',)


### PR DESCRIPTION
Just moved the slug field from info fieldset to first fieldset.

It would be nice if the error is on the field level instead of on the form level. But I guess this is handled by a dependency.