### PR TITLE
Add option to allow fallback language in post/category URLs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,12 @@
 History
 =======
 
+**********
+Unreleased
+**********
+
+* Add BLOG_USE_FALLBACK_LANGUAGE_IN_URL setting
+
 *******************
 1.1.1 (2020-05-15)
 *******************

--- a/djangocms_blog/settings.py
+++ b/djangocms_blog/settings.py
@@ -159,6 +159,8 @@ def get_setting(name):
 
         'BLOG_PLUGIN_TEMPLATE_FOLDERS': getattr(
             settings, 'BLOG_PLUGIN_TEMPLATE_FOLDERS', (('plugins', _('Default template')),)),
+        'BLOG_USE_FALLBACK_LANGUAGE_IN_URL': getattr(
+            settings, 'BLOG_USE_FALLBACK_LANGUAGE_IN_URL', False),
 
     }
     return default['BLOG_%s' % name]

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -99,6 +99,7 @@ Global Settings
 * BLOG_META_TITLE_LENGTH: Maximum length for the Meta title field (default: ``70``)
 * BLOG_ABSTRACT_CKEDITOR: Configuration for the CKEditor of the abstract field (as per https://github.com/divio/djangocms-text-ckeditor/#customizing-htmlfield-editor)
 * BLOG_POST_TEXT_CKEDITOR: Configuration for the CKEditor of the post content field
+* BLOG_USE_FALLBACK_LANGUAGE_IN_URL: When displaying URL, prefer URL in the fallback language if an article or category is not available in the current language
 
 ******************
 Read-only settings


### PR DESCRIPTION
Add setting BLOG_USE_FALLBACK_LANGUAGE_IN_URL. If enabled, and a blog post/category doesn't exist in the current language, prefer displaying the URL in the fallback language.

See issue https://github.com/nephila/djangocms-blog/issues/546 for context.