### PR TITLE
[setup.cfg] Add dependency to lxml

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,7 @@ install_requires =
      aldryn-apphooks-config>=0.5
      djangocms-apphook-setup
      django-sortedm2m
+     lxml
 setup_requires =
     setuptools
 packages = djangocms_blog


### PR DESCRIPTION
Thanks for commit c5bb3cd2db8c6d30204e54bc5dde74eaf85dfb53 and modernizing the build system and other tooling :)

`lxml` was dropped from the dependency list when migrating from setup.py to setup.cfg. This breaks the installation. Please merge this commit to restore the dependncy.