### PR TITLE
Do not let site crash on menu if there is a namespace mismatch

### DIFF
--- a/changes/532.bugfix
+++ b/changes/532.bugfix
@@ -1,0 +1,1 @@
+Do not let site crash on menu if there is a namespace mismatch

--- a/djangocms_blog/cms_menus.py
+++ b/djangocms_blog/cms_menus.py
@@ -51,7 +51,7 @@ class BlogCategoryMenu(CMSAttachMenu):
                     self._config[self.instance.application_namespace] = BlogConfig.objects.get(
                         namespace=self.instance.application_namespace
                     )
-                except Exception as e:
+                except BlogConfig.DoesNotExist as e:
                     logger.exception(e)
                     return []
             config = self._config[self.instance.application_namespace]

--- a/djangocms_blog/cms_menus.py
+++ b/djangocms_blog/cms_menus.py
@@ -1,3 +1,5 @@
+import logging
+
 from cms.apphook_pool import apphook_pool
 from cms.menu_bases import CMSAttachMenu
 from django.contrib.sites.shortcuts import get_current_site
@@ -10,6 +12,8 @@ from menus.menu_pool import menu_pool
 from .cms_appconfig import BlogConfig
 from .models import BlogCategory, Post
 from .settings import MENU_TYPE_CATEGORIES, MENU_TYPE_COMPLETE, MENU_TYPE_NONE, MENU_TYPE_POSTS, get_setting
+
+logger = logging.getLogger(__name__)
 
 
 class BlogCategoryMenu(CMSAttachMenu):
@@ -43,9 +47,13 @@ class BlogCategoryMenu(CMSAttachMenu):
         config = False
         if self.instance:
             if not self._config.get(self.instance.application_namespace, False):
-                self._config[self.instance.application_namespace] = BlogConfig.objects.get(
-                    namespace=self.instance.application_namespace
-                )
+                try:
+                    self._config[self.instance.application_namespace] = BlogConfig.objects.get(
+                        namespace=self.instance.application_namespace
+                    )
+                except Exception as e:
+                    logger.exception(e)
+                    return []
             config = self._config[self.instance.application_namespace]
             if not getattr(request, "toolbar", False) or not request.toolbar.edit_mode_active:
                 if self.instance == self.instance.get_draft_object():

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -4,8 +4,6 @@ from cms.api import create_page
 from django.test import Client
 from django.utils.encoding import force_str
 
-from djangocms_blog.cms_appconfig import BlogConfig
-
 from .base import BaseTest
 from .test_utils.models import CustomUser as User
 
@@ -49,19 +47,6 @@ class AdminTest(BaseTest):
         """
         Adjust advanced settings of a page with blog config create.
         """
-        self.assertEqual(BlogConfig.objects.count(), 2)
-
-        page = create_page("Blog", "blog.html", "en", published=True)
-        self.add_blog_config(page, "Blog", 1)
-        response = self.add_blog_config(page, "Blog", 1)
-        content = force_str(response.content)
-        self.assertNotRegex(content, r"Please correct the error below.")
-        self.assertEqual(BlogConfig.objects.count(), 2)
-
-        response = self.client.get("/en/blog/")
-        content = force_str(response.content)
-        self.assertRegex(content, r"No article found.")
-
         page = create_page("Blog2", "blog.html", "en", published=True)
         response = self.add_blog_config(page, "Blog2", "")
         content = force_str(response.content)

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -1,0 +1,73 @@
+from contextlib import contextmanager
+
+from cms.api import create_page
+from django.test import Client
+from django.utils.encoding import force_str
+
+from djangocms_blog.cms_appconfig import BlogConfig
+
+from .base import BaseTest
+from .test_utils.models import CustomUser as User
+
+try:
+    from knocker.signals import pause_knocks
+except ImportError:
+
+    @contextmanager
+    def pause_knocks(obj):
+        yield
+
+
+class AdminTest(BaseTest):
+    def setUp(self):
+        User.objects.create_superuser("test_admin", "admin@example.com", "Password123")
+
+    def add_blog_config(self, page, namespace, id):
+        self.client = Client()
+        self.client.login(username="test_admin", password="Password123")
+        response = self.client.post(
+            "/en/admin/cms/page/{}/advanced-settings/?language=en".format(page.pk),
+            {
+                "language": "nl",
+                "overwrite_url": "",
+                "redirect": "",
+                "template": "blog.html",
+                "reverse_id": "",
+                "navigation_extenders": "",
+                "application_urls": "BlogApp",
+                "application_namespace": namespace,
+                "application_configs": id,
+                "xframe_options": "0",
+                "_save": "Save",
+            },
+            follow=True,
+        )
+        self.client.logout()
+        return response
+
+    def test_add_blog_config(self):
+        """
+        Adjust advanced settings of a page with blog config create.
+        """
+        self.assertEqual(BlogConfig.objects.count(), 2)
+
+        page = create_page("Blog", "blog.html", "en", published=True)
+        self.add_blog_config(page, "Blog", 1)
+        response = self.add_blog_config(page, "Blog", 1)
+        content = force_str(response.content)
+        self.assertNotRegex(content, r"Please correct the error below.")
+        self.assertEqual(BlogConfig.objects.count(), 2)
+
+        response = self.client.get("/en/blog/")
+        content = force_str(response.content)
+        self.assertRegex(content, r"No article found.")
+
+        page = create_page("Blog2", "blog.html", "en", published=True)
+        response = self.add_blog_config(page, "Blog2", "")
+        content = force_str(response.content)
+        self.assertNotRegex(content, r"Please correct the error below.")
+        self.assertNotRegex(content, r"An application instance using this configuration already exists.")
+
+        response = self.client.get("/en/blog2/")
+        content = force_str(response.content)
+        self.assertRegex(content, r"Blog2")

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -5,7 +5,6 @@ from django.test import Client
 from django.utils.encoding import force_str
 
 from .base import BaseTest
-from .test_utils.models import CustomUser as User
 
 try:
     from knocker.signals import pause_knocks
@@ -17,12 +16,9 @@ except ImportError:
 
 
 class AdminTest(BaseTest):
-    def setUp(self):
-        User.objects.create_superuser("test_admin", "admin@example.com", "Password123")
-
     def add_blog_config(self, page, namespace, id):
         self.client = Client()
-        self.client.login(username="test_admin", password="Password123")
+        self.client.login(username=self._admin_user_username, password=self._admin_user_password)
         response = self.client.post(
             "/en/admin/cms/page/{}/advanced-settings/?language=en".format(page.pk),
             {


### PR DESCRIPTION
# Description
* When there is a namespace mismatch do not let menu templatetag throw an error
* 532 

## References
Fix #532 

# Checklist

* [x] I have read the [contribution guide](https://django-app-helper.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://django-app-helper.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [x] Tests added
