### PR TITLE
Check linting against fork branch to allow towncrier checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,9 @@ jobs:
         toxenv: [pep8, isort, black, pypi-description, docs, towncrier]
     steps:
     - uses: actions/checkout@v2
+      with:
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.ref }}
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:

--- a/tasks.py
+++ b/tasks.py
@@ -40,6 +40,7 @@ def towncrier_check(c):  # NOQA
     """ Check towncrier files. """
     output = io.StringIO()
     c.run("git branch -a --contains HEAD", out_stream=output)
+    print(output.getvalue())
     skipped_branch_prefix = ["pull/", "develop", "master", "HEAD"]
     # cleanup branch names by removing PR-only names in local, remote and disconnected branches to ensure the current
     # (i.e. user defined) branch name is used


### PR DESCRIPTION
# Description

`inv towncrier-check` needs the original branch name to check for changes file

In practice it's not an issue running the linting checks against the original branch instead of the merge commit because it's always up-to-date with target branch on this repo (worst case: it's updated via github if target branch is ahead of head)

## References

Fix #575 

# Checklist

* [x] I have read the [contribution guide](https://django-app-helper.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://django-app-helper.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [ ] Tests added
