### PR TITLE
Skip towncrier on develop / master branch

### DIFF
--- a/changes/591.bugfix
+++ b/changes/591.bugfix
@@ -1,0 +1,1 @@
+Skip towncrier on develop / master branch

--- a/tasks.py
+++ b/tasks.py
@@ -39,19 +39,23 @@ def format(c):  # NOQA
 def towncrier_check(c):  # NOQA
     """ Check towncrier files. """
     output = io.StringIO()
-    c.run("git branch -a --contains HEAD", out_stream=output)
-    print(output.getvalue())
+    c.run("git branch --contains HEAD", out_stream=output)
     skipped_branch_prefix = ["pull/", "develop", "master", "HEAD"]
     # cleanup branch names by removing PR-only names in local, remote and disconnected branches to ensure the current
     # (i.e. user defined) branch name is used
     branches = list(
         filter(
             lambda x: x and all(not x.startswith(part) for part in skipped_branch_prefix),
-            (branch.replace("remotes/", "").strip("* (") for branch in output.getvalue().split("\n")),
+            (
+                branch.replace("origin/", "").replace("remotes/", "").strip("* (")
+                for branch in output.getvalue().split("\n")
+            ),
         )
     )
+    print("Candidate branches", ", ".join(output.getvalue().split("\n")))
     if not branches:
         # if no branch name matches, we are in one of the excluded branches above, so we just exit
+        print("Skip check, branch excluded by configuration")
         return
     branch = branches[0]
     towncrier_file = None


### PR DESCRIPTION
# Description

Describe:

More aggressive branch skipping logic in towncrier-check task to avoid running on master / develop branches

## References

Fix #591 

# Checklist

* [x] I have read the [contribution guide](https://djangocms-blog.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://djangocms-blog.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [x] Usage documentation added in case of new features
* [x] Tests added
