### PR TITLE
Set default pytest configuration

### DIFF
--- a/changes/598.bugfix
+++ b/changes/598.bugfix
@@ -1,0 +1,1 @@
+Set default pytest configuration

--- a/tox.ini
+++ b/tox.ini
@@ -164,3 +164,9 @@ ignore =
     *.mo
 ignore-bad-ideas =
     *.mo
+
+[pytest]
+DJANGO_SETTINGS_MODULE = cms_helper
+python_files = test_*.py
+traceback = short
+addopts = --reuse-db


### PR DESCRIPTION
# Description

Describe:

Set default pytest configuration in `tox.ini`

## References

Fix #598 

# Checklist

* [x] I have read the [contribution guide](https://djangocms-blog.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://djangocms-blog.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [ ] Tests added
