### PR TITLE
Fix extra migration when customizing BLOG_PLUGIN_TEMPLATE_FOLDERS

### DIFF
--- a/changes/597.bugfix
+++ b/changes/597.bugfix
@@ -1,0 +1,1 @@
+Fix extra migration when customizing BLOG_PLUGIN_TEMPLATE_FOLDERS

--- a/djangocms_blog/migrations/0024_auto_20160706_1524.py
+++ b/djangocms_blog/migrations/0024_auto_20160706_1524.py
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
             model_name="authorentriesplugin",
             name="template_folder",
             field=models.CharField(
-                default="plugins",
+                default=BLOG_PLUGIN_TEMPLATE_FOLDERS[0][0],
                 verbose_name="Plugin template",
                 max_length=200,
                 help_text="Select plugin template to load for this instance",
@@ -27,7 +27,7 @@ class Migration(migrations.Migration):
             model_name="genericblogplugin",
             name="template_folder",
             field=models.CharField(
-                default="plugins",
+                default=BLOG_PLUGIN_TEMPLATE_FOLDERS[0][0],
                 verbose_name="Plugin template",
                 max_length=200,
                 help_text="Select plugin template to load for this instance",
@@ -38,7 +38,7 @@ class Migration(migrations.Migration):
             model_name="latestpostsplugin",
             name="template_folder",
             field=models.CharField(
-                default="plugins",
+                default=BLOG_PLUGIN_TEMPLATE_FOLDERS[0][0],
                 verbose_name="Plugin template",
                 max_length=200,
                 help_text="Select plugin template to load for this instance",


### PR DESCRIPTION
# Description

Use the setting value in the the migrations to not generate extra migration when customizing `BLOG_PLUGIN_TEMPLATE_FOLDERS`

## References

Fix #597 

# Checklist

* [x] I have read the [contribution guide](https://djangocms-blog.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://djangocms-blog.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [ ] Tests added
