### PR TITLE
Fix extra migration when customizing BLOG_PLUGIN_TEMPLATE_FOLDERS

### DIFF
--- a/djangocms_blog/migrations/0024_auto_20160706_1524.py
+++ b/djangocms_blog/migrations/0024_auto_20160706_1524.py
@@ -18,16 +18,16 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='authorentriesplugin',
             name='template_folder',
-            field=models.CharField(default='plugins', verbose_name='Plugin template', max_length=200, help_text='Select plugin template to load for this instance', choices=BLOG_PLUGIN_TEMPLATE_FOLDERS),
+            field=models.CharField(default=BLOG_PLUGIN_TEMPLATE_FOLDERS[0][0], verbose_name='Plugin template', max_length=200, help_text='Select plugin template to load for this instance', choices=BLOG_PLUGIN_TEMPLATE_FOLDERS),
         ),
         migrations.AddField(
             model_name='genericblogplugin',
             name='template_folder',
-            field=models.CharField(default='plugins', verbose_name='Plugin template', max_length=200, help_text='Select plugin template to load for this instance', choices=BLOG_PLUGIN_TEMPLATE_FOLDERS),
+            field=models.CharField(default=BLOG_PLUGIN_TEMPLATE_FOLDERS[0][0], verbose_name='Plugin template', max_length=200, help_text='Select plugin template to load for this instance', choices=BLOG_PLUGIN_TEMPLATE_FOLDERS),
         ),
         migrations.AddField(
             model_name='latestpostsplugin',
             name='template_folder',
-            field=models.CharField(default='plugins', verbose_name='Plugin template', max_length=200, help_text='Select plugin template to load for this instance', choices=BLOG_PLUGIN_TEMPLATE_FOLDERS),
+            field=models.CharField(default=BLOG_PLUGIN_TEMPLATE_FOLDERS[0][0], verbose_name='Plugin template', max_length=200, help_text='Select plugin template to load for this instance', choices=BLOG_PLUGIN_TEMPLATE_FOLDERS),
         ),
     ]


### PR DESCRIPTION
# Description

Use the setting value in the the migrations to not generate extra migration when customizing `BLOG_PLUGIN_TEMPLATE_FOLDERS`

## References

Fix #597 for 1.1

# Checklist

* [x] I have read the [contribution guide](https://djangocms-blog.readthedocs.io/en/latest/contributing.html)
* [ ] Code lint checked via `inv lint`
* [ ] ``changes`` file included (see [docs](https://djangocms-blog.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [ ] Tests added
