### PR TITLE
Bugfix/603 empy bullet for article sans publish date

### DIFF
--- a/changes/603.bugfix
+++ b/changes/603.bugfix
@@ -1,0 +1,1 @@
+Add missing condition for (date_published) <li> on blog_meta template

--- a/djangocms_blog/templates/djangocms_blog/includes/blog_meta.html
+++ b/djangocms_blog/templates/djangocms_blog/includes/blog_meta.html
@@ -6,9 +6,11 @@
         {% trans "by" %} <a href="{% url 'djangocms_blog:posts-author' post.author.get_username %}">{% if post.author.get_full_name %}{{ post.author.get_full_name }}{% else %}{{ post.author }}{% endif %}</a>
     </li>
     {% endif %}
+    {% if post.date_published %}
     <li>
         {{ post.date_published|date:"DATE_FORMAT" }}
     </li>
+    {% endif %}
     {% if post.date_featured %}
     <li>
         {{ post.date_featured|date:"DATE_FORMAT" }}


### PR DESCRIPTION
# Description

Describe:

* Add `{% if %}` condition around markup.
* Prevent empty `<li>` from showing in missing condition.

## References

Fix #603

# Checklist

* [x] I have read the [contribution guide](https://djangocms-blog.readthedocs.io/en/latest/contributing.html)
* [ ] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://djangocms-blog.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [ ] Tests added
