### PR TITLE
Restore normal python versions declaration in tox 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,7 @@ jobs:
         python -m pip install --upgrade pip tox>=3.5
     - name: Test with tox
       env:
-        TOX_ENV: ${{ format('py{0}-django{1}-cms{2}', matrix.python-version, matrix.django, matrix.cms) }}
+        TOX_ENV: ${{ format('py-django{1}-cms{2}', matrix.python-version, matrix.django, matrix.cms) }}
         COMMAND: coverage run
         COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COVERALLS_SERVICE_NAME: github

--- a/changes/606.bugfix
+++ b/changes/606.bugfix
@@ -1,0 +1,1 @@
+Fix python version declaration in tox

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,8 @@ envlist =
     pep8
     pypi-description
     towncrier
-    py{3.8,3.7,3.6}-django{30}-cms{37,no-search-37}
-    py{3.8,3.7,3.6,3.5}-django{22}-cms{37,no-search-37}
+    py{38,37,36}-django{30}-cms{37,no-search-37}
+    py{38,37,36,35}-django{22}-cms{37,no-search-37}
 
 [testenv]
 commands = {env:COMMAND:python} cms_helper.py djangocms_blog test {posargs}


### PR DESCRIPTION
# Description

Drop the dot in tox environment definitions by using generic python environment in GA

## References

Fix #606 

# Checklist

* [x] I have read the [contribution guide](https://djangocms-blog.readthedocs.io/en/latest/contributing.html)
* [ ] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://djangocms-blog.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [ ] Tests added
