### PR TITLE
Split linting GA to its own file

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -17,7 +17,7 @@ Please fill in each section to help maintainers to be helpful and quick to respo
 Describe issue in general terms.
 -->
 
-## Steps to reproduce
+## Steps to reproduce
 
 <!--
 Provide clear steps to reproduce the issue.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,41 @@
+name: Code quality
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    strategy:
+      matrix:
+        python-version: [3.8]
+        toxenv: [pep8, isort, black, pypi-description, docs, towncrier]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.ref }}
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Cache pip
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ matrix.toxenv }}
+        restore-keys: |
+          ${{ runner.os }}-pip-${{ matrix.toxenv }}
+    - name: Cache tox
+      uses: actions/cache@v1
+      with:
+        path: .tox
+        key: ${{ runner.os }}-lint-${{ matrix.toxenv }}-${{ hashFiles('setup.cfg') }}
+        restore-keys: |
+          ${{ runner.os }}-lint-${{ matrix.toxenv }}-
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools tox>=1.8
+    - name: Test with tox
+      run: |
+        tox -e${{ matrix.toxenv }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,45 +1,8 @@
-name: Linting - Tests
+name: Tox tests
 
 on: [push, pull_request]
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
-    strategy:
-      matrix:
-        python-version: [3.8]
-        toxenv: [pep8, isort, black, pypi-description, docs, towncrier]
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        repository: ${{ github.event.pull_request.head.repo.full_name }}
-        ref: ${{ github.event.pull_request.head.ref }}
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Cache pip
-      uses: actions/cache@v1
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ matrix.toxenv }}
-        restore-keys: |
-          ${{ runner.os }}-pip-${{ matrix.toxenv }}
-    - name: Cache tox
-      uses: actions/cache@v1
-      with:
-        path: .tox
-        key: ${{ runner.os }}-lint-${{ matrix.toxenv }}-${{ hashFiles('setup.cfg') }}
-        restore-keys: |
-          ${{ runner.os }}-lint-${{ matrix.toxenv }}-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip setuptools tox>=1.8
-    - name: Test with tox
-      run: |
-        tox -e${{ matrix.toxenv }}
-
   test:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-latest

--- a/changes/608.bugfix
+++ b/changes/608.bugfix
@@ -1,0 +1,1 @@
+Split linting GA to its own file


### PR DESCRIPTION
# Description

Split linting workflow in its own file

Fix typo in bug issues template

## References

Fix #608 

# Checklist

* [x] I have read the [contribution guide](https://djangocms-blog.readthedocs.io/en/latest/contributing.html)
* [ ] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://djangocms-blog.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [ ] Tests added
