### PR TITLE
Fix creating text plugin in wizard

### DIFF
--- a/changes/607.bugfix
+++ b/changes/607.bugfix
@@ -1,0 +1,1 @@
+Fix creating text plugin in wizard

--- a/djangocms_blog/settings.py
+++ b/djangocms_blog/settings.py
@@ -119,5 +119,7 @@ def get_setting(name):
             settings, "BLOG_PLUGIN_TEMPLATE_FOLDERS", (("plugins", _("Default template")),)
         ),
         "BLOG_USE_FALLBACK_LANGUAGE_IN_URL": getattr(settings, "BLOG_USE_FALLBACK_LANGUAGE_IN_URL", False),
+        "BLOG_WIZARD_CONTENT_PLUGIN": getattr(settings, "BLOG_WIZARD_CONTENT_PLUGIN", "TextPlugin"),
+        "BLOG_WIZARD_CONTENT_PLUGIN_BODY": getattr(settings, "BLOG_WIZARD_CONTENT_PLUGIN_BODY", "body"),
     }
     return default["BLOG_%s" % name]

--- a/docs/features/wizard.rst
+++ b/docs/features/wizard.rst
@@ -14,3 +14,12 @@ Some issues with multiple registrations raising django CMS ``AlreadyRegisteredEx
 hae been reported; to handle these cases gracefully, the exception is swallowed
 when Django ``DEBUG == True`` avoiding breaking production websites. In these cases they
 wizard may not show up, but the rest will work as intended.
+
+Wizard can create blog post content by filling the ``Text`` form field. You can control the text plugin used for
+content creation by editing two settings:
+
+* ``BLOG_WIZARD_CONTENT_PLUGIN``: name of the plugin to use (default: ``TextPlugin``)
+* ``BLOG_WIZARD_CONTENT_PLUGIN_BODY``: name of the plugin field to add text to (default: ``body``)
+
+.. warning:: the plugin used must only have the text field required, all additional fields must be optional, otherwise
+             the wizard will fail.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -100,6 +100,8 @@ Global Settings
 * BLOG_ABSTRACT_CKEDITOR: Configuration for the CKEditor of the abstract field (as per https://github.com/divio/djangocms-text-ckeditor/#customizing-htmlfield-editor)
 * BLOG_POST_TEXT_CKEDITOR: Configuration for the CKEditor of the post content field
 * BLOG_USE_FALLBACK_LANGUAGE_IN_URL: When displaying URL, prefer URL in the fallback language if an article or category is not available in the current language
+* BLOG_WIZARD_CONTENT_PLUGIN: name of the plugin created by wizard for the text content (default: ``TextPlugin``)
+* BLOG_WIZARD_CONTENT_PLUGIN_BODY: name of the plugin field to add wizard text (default: ``body``)
 
 ******************
 Read-only settings


### PR DESCRIPTION
# Description

Implement missing part regarding adding text content as a plugin if `use_placeholder` setting is enabled

## References

Fix #607 

# Checklist

* [x] I have read the [contribution guide](https://djangocms-blog.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://djangocms-blog.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [x] Usage documentation added in case of new features
* [x] Tests added
