### PR TITLE
Fix missing template folders selection in plugins

### DIFF
--- a/changes/595.bugfix
+++ b/changes/595.bugfix
@@ -1,0 +1,1 @@
+Fix missing template folders selection in plugins

--- a/djangocms_blog/cms_plugins.py
+++ b/djangocms_blog/cms_plugins.py
@@ -6,15 +6,21 @@ from django.contrib.sites.shortcuts import get_current_site
 from django.db import models
 from django.template.loader import select_template
 
-from .forms import AuthorPostsForm, LatestEntriesForm
+from .forms import AuthorPostsForm, BlogPluginForm, LatestEntriesForm
 from .models import AuthorEntriesPlugin, BlogCategory, GenericBlogPlugin, LatestPostsPlugin, Post
 from .settings import get_setting
 
 
 class BlogPlugin(CMSPluginBase):
     module = get_setting("PLUGIN_MODULE_NAME")
+    form = BlogPluginForm
 
     def get_render_template(self, context, instance, placeholder):
+        """
+        Select the template used to render the plugin.
+
+        Check the default folder as well as the folders provided to the apphook config.
+        """
         templates = [os.path.join("djangocms_blog", instance.template_folder, self.base_render_template)]
         if instance.app_config and instance.app_config.template_prefix:
             templates.insert(
@@ -26,75 +32,83 @@ class BlogPlugin(CMSPluginBase):
         return selected.template.name
 
 
+@plugin_pool.register_plugin
 class BlogLatestEntriesPlugin(BlogPlugin):
     """
-    Non cached plugin which returns the latest posts taking into account the
-      user / toolbar state
+    Return the latest published posts which bypasses cache,  taking into account the user / toolbar state.
     """
 
     name = get_setting("LATEST_ENTRIES_PLUGIN_NAME")
     model = LatestPostsPlugin
     form = LatestEntriesForm
     filter_horizontal = ("categories",)
-    fields = (
-        ["app_config", "latest_posts", "tags", "categories"] + ["template_folder"]
-        if len(get_setting("PLUGIN_TEMPLATE_FOLDERS")) > 1
-        else []
-    )
     cache = False
     base_render_template = "latest_entries.html"
 
+    def get_fields(self, request, obj=None):
+        """
+        Return the fields available when editing the plugin.
+
+        'template_folder' field is added if ``BLOG_PLUGIN_TEMPLATE_FOLDERS`` contains multiple folders.
+
+        """
+        fields = ["app_config", "latest_posts", "tags", "categories"]
+        if len(get_setting("PLUGIN_TEMPLATE_FOLDERS")) > 1:
+            fields.append("template_folder")
+        return fields
+
     def render(self, context, instance, placeholder):
+        """Render the plugin."""
         context = super().render(context, instance, placeholder)
         context["posts_list"] = instance.get_posts(context["request"], published_only=False)
         context["TRUNCWORDS_COUNT"] = get_setting("POSTS_LIST_TRUNCWORDS_COUNT")
         return context
 
 
-class BlogLatestEntriesPluginCached(BlogPlugin):
+@plugin_pool.register_plugin
+class BlogLatestEntriesPluginCached(BlogLatestEntriesPlugin):
     """
-    Cached plugin which returns the latest published posts
+    Return the latest published posts caching the result.
     """
 
     name = get_setting("LATEST_ENTRIES_PLUGIN_NAME_CACHED")
-    model = LatestPostsPlugin
-    form = LatestEntriesForm
-    filter_horizontal = ("categories",)
-    fields = (
-        ["app_config", "latest_posts", "tags", "categories"] + ["template_folder"]
-        if len(get_setting("PLUGIN_TEMPLATE_FOLDERS")) > 1
-        else []
-    )
-    base_render_template = "latest_entries.html"
-
-    def render(self, context, instance, placeholder):
-        context = super().render(context, instance, placeholder)
-        context["posts_list"] = instance.get_posts(context["request"])
-        context["TRUNCWORDS_COUNT"] = get_setting("POSTS_LIST_TRUNCWORDS_COUNT")
-        return context
+    cache = True
 
 
+@plugin_pool.register_plugin
 class BlogAuthorPostsPlugin(BlogPlugin):
+    """Render the list of authors."""
+
     module = get_setting("PLUGIN_MODULE_NAME")
     name = get_setting("AUTHOR_POSTS_PLUGIN_NAME")
     model = AuthorEntriesPlugin
     form = AuthorPostsForm
     base_render_template = "authors.html"
     filter_horizontal = ["authors"]
-    fields = (
-        ["app_config", "current_site", "authors"] + ["template_folder"]
-        if len(get_setting("PLUGIN_TEMPLATE_FOLDERS")) > 1
-        else []
-    )
-    exclude = ["template_folder"] if len(get_setting("PLUGIN_TEMPLATE_FOLDERS")) >= 1 else []
+
+    def get_fields(self, request, obj=None):
+        """
+        Return the fields available when editing the plugin.
+
+        'template_folder' field is added if ``BLOG_PLUGIN_TEMPLATE_FOLDERS`` contains multiple folders.
+
+        """
+        fields = ["app_config", "current_site", "authors"]
+        if len(get_setting("PLUGIN_TEMPLATE_FOLDERS")) > 1:
+            fields.append("template_folder")
+        return fields
 
     def render(self, context, instance, placeholder):
+        """Render the plugin."""
         context = super().render(context, instance, placeholder)
         context["authors_list"] = instance.get_authors(context["request"])
         return context
 
 
+@plugin_pool.register_plugin
 class BlogAuthorPostsListPlugin(BlogAuthorPostsPlugin):
+    """Render the list of posts for each selected author."""
+
     name = get_setting("AUTHOR_POSTS_LIST_PLUGIN_NAME")
     base_render_template = "authors_posts.html"
     fields = (
@@ -103,29 +117,55 @@ class BlogAuthorPostsListPlugin(BlogAuthorPostsPlugin):
         else []
     )
 
+    def get_fields(self, request, obj=None):
+        """
+        Return the fields available when editing the plugin.
 
+        'template_folder' field is added if ``BLOG_PLUGIN_TEMPLATE_FOLDERS`` contains multiple folders.
+
+        """
+        fields = ["app_config", "current_site", "authors", "latest_posts"]
+        if len(get_setting("PLUGIN_TEMPLATE_FOLDERS")) > 1:
+            fields.append("template_folder")
+        return fields
+
+
+@plugin_pool.register_plugin
 class BlogTagsPlugin(BlogPlugin):
+    """Render the list of post tags."""
+
     module = get_setting("PLUGIN_MODULE_NAME")
     name = get_setting("TAGS_PLUGIN_NAME")
     model = GenericBlogPlugin
     base_render_template = "tags.html"
-    exclude = ["template_folder"] if len(get_setting("PLUGIN_TEMPLATE_FOLDERS")) >= 1 else []
+
+    def get_exclude(self, request, obj=None):
+        """Exclude 'template_folder' field if ``BLOG_PLUGIN_TEMPLATE_FOLDERS`` contains one folder."""
+        return [] if len(get_setting("PLUGIN_TEMPLATE_FOLDERS")) > 1 else ["template_folder"]
 
     def render(self, context, instance, placeholder):
+        """Render the plugin."""
         context = super().render(context, instance, placeholder)
         qs = instance.post_queryset(context["request"])
         context["tags"] = Post.objects.tag_cloud(queryset=qs.published())
         return context
 
 
+@plugin_pool.register_plugin
 class BlogCategoryPlugin(BlogPlugin):
+    """Render the list of post categories."""
+
     module = get_setting("PLUGIN_MODULE_NAME")
     name = get_setting("CATEGORY_PLUGIN_NAME")
     model = GenericBlogPlugin
     base_render_template = "categories.html"
-    exclude = ["template_folder"] if len(get_setting("PLUGIN_TEMPLATE_FOLDERS")) >= 1 else []
+
+    def get_exclude(self, request, obj=None):
+        """Exclude 'template_folder' field if ``BLOG_PLUGIN_TEMPLATE_FOLDERS`` contains one folder."""
+        return [] if len(get_setting("PLUGIN_TEMPLATE_FOLDERS")) > 1 else ["template_folder"]
 
     def render(self, context, instance, placeholder):
+        """Render the plugin."""
         context = super().render(context, instance, placeholder)
         qs = BlogCategory.objects.active_translations()
         if instance.app_config:
@@ -140,24 +180,22 @@ class BlogCategoryPlugin(BlogPlugin):
         return context
 
 
+@plugin_pool.register_plugin
 class BlogArchivePlugin(BlogPlugin):
+    """Render the list of months with available posts."""
+
     module = get_setting("PLUGIN_MODULE_NAME")
     name = get_setting("ARCHIVE_PLUGIN_NAME")
     model = GenericBlogPlugin
     base_render_template = "archive.html"
-    exclude = ["template_folder"] if len(get_setting("PLUGIN_TEMPLATE_FOLDERS")) >= 1 else []
+
+    def get_exclude(self, request, obj=None):
+        """Exclude 'template_folder' field if ``BLOG_PLUGIN_TEMPLATE_FOLDERS`` contains one folder."""
+        return [] if len(get_setting("PLUGIN_TEMPLATE_FOLDERS")) > 1 else ["template_folder"]
 
     def render(self, context, instance, placeholder):
+        """Render the plugin."""
         context = super().render(context, instance, placeholder)
         qs = instance.post_queryset(context["request"])
         context["dates"] = Post.objects.get_months(queryset=qs.published())
         return context
-
-
-plugin_pool.register_plugin(BlogLatestEntriesPlugin)
-plugin_pool.register_plugin(BlogLatestEntriesPluginCached)
-plugin_pool.register_plugin(BlogAuthorPostsPlugin)
-plugin_pool.register_plugin(BlogAuthorPostsListPlugin)
-plugin_pool.register_plugin(BlogTagsPlugin)
-plugin_pool.register_plugin(BlogArchivePlugin)
-plugin_pool.register_plugin(BlogCategoryPlugin)

--- a/djangocms_blog/forms.py
+++ b/djangocms_blog/forms.py
@@ -62,7 +62,14 @@ class CategoryAdminForm(ConfigFormBase, TranslatableModelForm):
         fields = "__all__"
 
 
-class LatestEntriesForm(forms.ModelForm):
+class BlogPluginForm(forms.ModelForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if "template_folder" in self.fields:
+            self.fields["template_folder"].choices = get_setting("PLUGIN_TEMPLATE_FOLDERS")
+
+
+class LatestEntriesForm(BlogPluginForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["tags"].widget = TagAutoSuggest("taggit.Tag")
@@ -71,7 +78,7 @@ class LatestEntriesForm(forms.ModelForm):
         css = {"all": ("{}djangocms_blog/css/{}".format(settings.STATIC_URL, "djangocms_blog_admin.css"),)}
 
 
-class AuthorPostsForm(forms.ModelForm):
+class AuthorPostsForm(BlogPluginForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # apply distinct due to django issue #11707

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -345,7 +345,7 @@ class PluginTest10(BaseTest):
             response = page_admin.add_plugin(request)
             template_folder_field = response.context_data["adminform"].form.fields["template_folder"]
             self.assertEqual(len(template_folder_field.choices), 2)
-            self.assertEqual(list(dict(template_folder_field.choices).keys()), ["default", "vertical"])
+            self.assertEqual(sorted(dict(template_folder_field.choices).keys()), sorted(["default", "vertical"]))
 
 
 class PluginTest2(BaseTest):


### PR DESCRIPTION
# Description

`exclude` attribute use a wrong condition to exclude ``template_folders`` from form

Refactor `fields`, `exclude` as methods for easier testing

Use decorator-style plugin registration

## References

Reference #595 

# Checklist

* [x] I have read the [contribution guide](https://djangocms-blog.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://djangocms-blog.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [x] Usage documentation added in case of new features
* [x] Tests added
