### PR TITLE
Improve admin customization

### DIFF
--- a/changes/620.feature
+++ b/changes/620.feature
@@ -1,0 +1,1 @@
+Improve admin customization

--- a/djangocms_blog/admin.py
+++ b/djangocms_blog/admin.py
@@ -154,7 +154,7 @@ class PostAdmin(PlaceholderAdminMixin, FrontendEditableAdminMixin, ModelAppHookC
         "post_text": (0, 1),
         "sites": (1, 1, 0),
         "author": (1, 1, 0),
-        "enable_liveblog": (2, 1),
+        "enable_liveblog": (2, 1, 2),
         "related": (1, 1, 0),
     }
     """

--- a/docs/features/admin_customization.rst
+++ b/docs/features/admin_customization.rst
@@ -1,0 +1,90 @@
+.. _admin_customization:
+
+###################
+Admin customization
+###################
+
+As any other django model admin, :py:class:`PostAdmin` can be customized by extending it adding a subclass in one of the
+project's applications.
+
+.. code-block:: python
+   :name: project_app/admin.py
+
+    admin.site.unregister(Post)
+    @admin.register(Post)
+    class CustomPostAdmin(PostAdmin):
+        ...
+        you_attributes_and_methods
+
+
+*************************
+Customizing the fieldsets
+*************************
+
+Due to the logic in :py:meth:`djangocms_blog.admin.PostAdmin.get_fieldsets` method, it's advised to customize the
+fieldsets by overriding two private attributes :py:attr:`djangocms_blog.admin.PostAdmin._fieldsets` and
+:py:attr:`djangocms_blog.admin.PostAdmin._fieldset_extra_fields_position`.
+
+_fieldsets
+=================
+
+``_fieldsets`` attribute follow the standard `Django Admin fieldset`_ structure. This is the primary source for customization.
+
+You can freely rearrange and remove fields from this structure as you would to in a normal ``fieldsets`` attribute; the only
+caveat is that you must ensure consistency extra fields position set by ``_fieldset_extra_fields_position``.
+
+
+_fieldset_extra_fields_position
+===============================
+
+As some fields are managed by settings and apphook config, they are added to the final ``fieldsets`` by ``PostAdmin.get_fieldsets``;
+you can customize their position (or hide them) by overriding ``_fieldset_extra_fields_position`` attribute.
+
+The attribute is a dictionary containing the fields name as key, and by providing their position in the fieldsets as tuple.
+
+Use a 2-item tuple if the field must be appended at the row level (e.g.: ``(None, {"fields": ["field_a", "field_b"]})``) or
+a 3-item tuple if the field must be appended in a subgroup (e.g.: ``(None, {"fields": ["field_a", ["field_b"[]})``.
+
+Example
+===============================
+
+.. code-block:: python
+   :name: my_app/admin.py
+
+    admin.site.unregister(Post)
+    @admin.register(Post)
+    class CustomPostAdmin(PostAdmin):
+        ...
+        _fieldsets = [
+            (None, {"fields": ["title", "subtitle", "slug", "publish", "categories"]}),
+            (
+                _("Info"),
+                {
+                    "fields": [["tags"], ["date_published", "date_published_end", "date_featured"], "app_config", "enable_comments"],
+                    "classes": ("collapse",),
+                },
+            ),
+            (
+                _("Images"),
+                {"fields": [["main_image", "main_image_thumbnail", "main_image_full"]], "classes": ("collapse",)},
+            ),
+            (_("SEO"), {"fields": [["meta_description", "meta_title", "meta_keywords"]], "classes": ("collapse",)}),
+        ]
+        _fieldset_extra_fields_position = {
+            "abstract": [0, 1],
+            "post_text": [0, 1],
+            "sites": [1, 1, 0],
+            "author": [1, 1],
+            "enable_liveblog": None,
+            "related": [1, 1, 0],
+        }
+
+This example will result in:
+
+* ``"enable_liveblog"``: hidden even if enabled in settings
+* ``"sites"``: added in the same subgroup as ``"tags"``
+* ``"author"``: appended after the ``"enable_comments"`` field
+* ``"app_config"`` field moved to ``"Info"`` fieldset
+
+
+.. _django admin fieldset: https://docs.djangoproject.com/en/3.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.fieldsets

--- a/docs/features/index.rst
+++ b/docs/features/index.rst
@@ -11,6 +11,7 @@ Features
    urlconf
    permalinks
    templates
+   admin_customization
    shares
    media
    menu

--- a/tests/test_utils/admin.py
+++ b/tests/test_utils/admin.py
@@ -2,9 +2,13 @@ from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.utils.translation import gettext_lazy as _
 
+from djangocms_blog.admin import PostAdmin
+from djangocms_blog.models import Post
+
 from .models import CustomUser, PostExtension
 
 
+@admin.register(CustomUser)
 class CustomUserAdmin(UserAdmin):
     model = CustomUser
 
@@ -17,7 +21,39 @@ class CustomUserAdmin(UserAdmin):
     )
 
 
-admin.site.register(CustomUser, CustomUserAdmin)
+admin.site.unregister(Post)
+
+
+@admin.register(Post)
+class CustomPostAdmin(PostAdmin):
+    _fieldsets = [
+        (None, {"fields": ["title", "subtitle", "slug", "publish", "categories"]}),
+        (
+            _("Info"),
+            {
+                "fields": [
+                    ["tags"],
+                    ["date_published", "date_published_end", "date_featured"],
+                    "app_config",
+                    "enable_comments",
+                ],
+                "classes": ("collapse",),
+            },
+        ),
+        (
+            _("Images"),
+            {"fields": [["main_image", "main_image_thumbnail", "main_image_full"]], "classes": ("collapse",)},
+        ),
+        (_("SEO"), {"fields": [["meta_description", "meta_title", "meta_keywords"]], "classes": ("collapse",)}),
+    ]
+    _fieldset_extra_fields_position = {
+        "abstract": [0, 1],
+        "post_text": [0, 1],
+        "sites": [1, 1, 0],
+        "author": [1, 1],
+        "enable_liveblog": None,
+        "related": [1, 1, 0],
+    }
 
 
 class PostExtensionInline(admin.TabularInline):

--- a/tests/test_utils/admin.py
+++ b/tests/test_utils/admin.py
@@ -3,7 +3,6 @@ from django.contrib.auth.admin import UserAdmin
 from django.utils.translation import gettext_lazy as _
 
 from djangocms_blog.admin import PostAdmin
-from djangocms_blog.models import Post
 
 from .models import CustomUser, PostExtension
 
@@ -21,10 +20,6 @@ class CustomUserAdmin(UserAdmin):
     )
 
 
-admin.site.unregister(Post)
-
-
-@admin.register(Post)
 class CustomPostAdmin(PostAdmin):
     _fieldsets = [
         (None, {"fields": ["title", "subtitle", "slug", "publish", "categories"]}),
@@ -52,7 +47,7 @@ class CustomPostAdmin(PostAdmin):
         "sites": [1, 1, 0],
         "author": [1, 1],
         "enable_liveblog": None,
-        "related": [1, 1, 0],
+        "related": None,
     }
 
 


### PR DESCRIPTION
# Description

Add attribute to customize position of extra / optional fields

Document the proper way to extend `PostAdmin`


## References

Fix #620 

# Checklist

* [x] I have read the [contribution guide](https://djangocms-blog.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://djangocms-blog.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [x] Usage documentation added in case of new features
* [x] Tests added
