### PR TITLE
Add support to django-meta 2.0 replacing g+ attributes with schema.org

### DIFF
--- a/changes/637.feature
+++ b/changes/637.feature
@@ -1,0 +1,1 @@
+Replace G+ metadata with Schema.org

--- a/djangocms_blog/admin.py
+++ b/djangocms_blog/admin.py
@@ -532,7 +532,7 @@ class BlogConfigAdmin(BaseAppHookConfig, TranslatableAdmin):
                 },
             ),
             (
-                "Google+",
+                "Schema.org",
                 {
                     "fields": (
                         "config.gplus_type",

--- a/djangocms_blog/cms_appconfig.py
+++ b/djangocms_blog/cms_appconfig.py
@@ -27,6 +27,11 @@ class BlogConfig(TranslatableModel, AppHookConfig):
     def get_app_title(self):
         return getattr(self, "app_title", _("untitled"))
 
+    @property
+    def schemaorg_type(self):
+        """Compatibility shim to fetch data from legacy gplus_type field."""
+        return self.gplus_type
+
 
 class BlogConfigForm(AppDataForm):
     """
@@ -176,13 +181,16 @@ class BlogConfigForm(AppDataForm):
     twitter_author = forms.CharField(
         max_length=200, label=_("Twitter author handle"), required=False, initial=get_setting("TWITTER_AUTHOR")
     )
-    #: Schema.org object type (default: :ref:`GPLUS_TYPE <GPLUS_TYPE>`)
+    #: Schema.org object type (default: :ref:`SCHEMAORG_TYPE <SCHEMAORG_TYPE>`)
     gplus_type = forms.ChoiceField(
-        label=_("Google+ type"), required=False, choices=get_setting("GPLUS_TYPES"), initial=get_setting("GPLUS_TYPE")
+        label=_("Schema.org type"),
+        required=False,
+        choices=get_setting("SCHEMAORG_TYPES"),
+        initial=get_setting("SCHEMAORG_TYPE"),
     )
-    #: Google+ author name abstract field (default: :ref:`GPLUS_AUTHOR <GPLUS_AUTHOR>`)
+    #: Schema.org author name abstract field (default: :ref:`SCHEMAORG_AUTHOR <SCHEMAORG_AUTHOR>`)
     gplus_author = forms.CharField(
-        max_length=200, label=_("Google+ author name"), required=False, initial=get_setting("GPLUS_AUTHOR")
+        max_length=200, label=_("Schema.org author name"), required=False, initial=get_setting("SCHEMAORG_AUTHOR")
     )
     #: Send notifications on post update. Require channels integration
     send_knock_create = forms.BooleanField(

--- a/djangocms_blog/models.py
+++ b/djangocms_blog/models.py
@@ -73,6 +73,7 @@ class BlogMetaMixin(ModelMeta):
         Retrieves django-meta attributes from apphook config instance
         :param param: django-meta attribute passed as key
         """
+        print(param, getattr(self.app_config, param))
         return self._get_meta_value(param, getattr(self.app_config, param)) or ""
 
     def get_locale(self):
@@ -111,7 +112,8 @@ class BlogCategory(BlogMetaMixin, TranslatableModel):
         "description": "get_description",
         "og_description": "get_description",
         "twitter_description": "get_description",
-        "gplus_description": "get_description",
+        "schemaorg_description": "get_description",
+        "schemaorg_type": "get_meta_attribute",
         "locale": "get_locale",
         "object_type": "get_meta_attribute",
         "og_type": "get_meta_attribute",
@@ -123,8 +125,6 @@ class BlogCategory(BlogMetaMixin, TranslatableModel):
         "twitter_type": "get_meta_attribute",
         "twitter_site": "get_meta_attribute",
         "twitter_author": "get_meta_attribute",
-        "gplus_type": "get_meta_attribute",
-        "gplus_author": "get_meta_attribute",
         "url": "get_absolute_url",
     }
 
@@ -284,7 +284,7 @@ class Post(KnockerModel, BlogMetaMixin, TranslatableModel):
         "keywords": "get_keywords",
         "og_description": "get_description",
         "twitter_description": "get_description",
-        "gplus_description": "get_description",
+        "schemaorg_description": "get_description",
         "locale": "get_locale",
         "image": "get_image_full_url",
         "image_width": "get_image_width",
@@ -299,8 +299,7 @@ class Post(KnockerModel, BlogMetaMixin, TranslatableModel):
         "twitter_type": "get_meta_attribute",
         "twitter_site": "get_meta_attribute",
         "twitter_author": "get_meta_attribute",
-        "gplus_type": "get_meta_attribute",
-        "gplus_author": "get_meta_attribute",
+        "schemaorg_type": "get_meta_attribute",
         "published_time": "date_published",
         "modified_time": "date_modified",
         "expiration_time": "date_published_end",

--- a/djangocms_blog/settings.py
+++ b/djangocms_blog/settings.py
@@ -250,25 +250,25 @@ BLOG_TWITTER_AUTHOR = "get_author_twitter"
 Twitter account of the post author.
 """
 
-BLOG_GPLUS_TYPE = "Blog"
+BLOG_SCHEMAORG_TYPE = "Blog"
 """
-.. _GPLUS_TYPE:
+.. _SCHEMAORG_TYPE:
 
 Schema.org type for the post object.
 """
 
-BLOG_GPLUS_TYPES = meta_settings.GPLUS_TYPES
+BLOG_SCHEMAORG_TYPES = meta_settings.SCHEMAORG_TYPES
 """
-.. _GPLUS_TYPES:
+.. _SCHEMAORG_TYPES:
 
 Choices of available Schema.org types.
 
-Default from ``GPLUS_TYPES`` defined in `django-meta settings`_.
+Default from ``SCHEMAORG_TYPES`` defined in `django-meta settings`_.
 """
 
-BLOG_GPLUS_AUTHOR = "get_author_gplus"
+BLOG_SCHEMAORG_AUTHOR = "get_author_schemaorg"
 """
-.. _GPLUS_AUTHOR:
+.. _SCHEMAORG_AUTHOR:
 
 Google+ account of the post author (deprecated).
 """

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,7 @@ install_requires =
      django-taggit-autosuggest
      djangocms-text-ckeditor>=3.9
      easy-thumbnails>=2.4.1
-     django-meta>=1.4
+     django-meta>=2.0
      aldryn-apphooks-config>=0.5
      djangocms-apphook-setup
      django-sortedm2m

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -842,9 +842,6 @@ class ModelsTest(BaseTest):
     def test_model_attributes(self):
         self.get_pages()
 
-        self.app_config_1.app_data.config.gplus_author = "RandomJoe"
-        self.app_config_1.save()
-
         featured_date = now() + timedelta(days=40)
 
         post = self._get_post(self._post_data[0]["en"])
@@ -870,8 +867,9 @@ class ModelsTest(BaseTest):
         self.assertEqual(meta_en.twitter_site, "")
         self.assertEqual(meta_en.twitter_author, "")
         self.assertEqual(meta_en.twitter_type, "summary")
-        self.assertEqual(meta_en.gplus_author, "RandomJoe")
-        self.assertEqual(meta_en.gplus_type, "Blog")
+        self.assertEqual(meta_en.schemaorg_type, "Blog")
+        self.assertEqual(meta_en.schemaorg_title, post.title)
+        self.assertEqual(meta_en.schemaorg_description, post.meta_description)
         self.assertEqual(meta_en.og_type, "Article")
         self.assertEqual(meta_en.image_width, post.main_image.width)
         self.assertEqual(meta_en.image_height, post.main_image.height)
@@ -892,8 +890,7 @@ class ModelsTest(BaseTest):
         self.assertEqual(meta_cat.twitter_site, "")
         self.assertEqual(meta_cat.twitter_author, "")
         self.assertEqual(meta_cat.twitter_type, "summary")
-        self.assertEqual(meta_cat.gplus_author, "RandomJoe")
-        self.assertEqual(meta_cat.gplus_type, "Blog")
+        self.assertEqual(meta_cat.schemaorg_type, "Blog")
         self.assertEqual(meta_cat.og_type, "Article")
         self.assertEqual(meta_cat.facebook_app_id, None)
         self.assertTrue(meta_cat.url.endswith(category.get_absolute_url()))


### PR DESCRIPTION
# Description

django-meta 2.0 drops g+ in favour of schema.org

appconfig fields names are kept unchanged to avoid a data migration

## References

Fix #627

# Checklist

* [x] I have read the [contribution guide](https://djangocms-blog.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://djangocms-blog.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [x] Usage documentation added in case of new features
* [x] Tests added
