### PR TITLE
Replace url function with path

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,9 @@ Supported django CMS versions:
 
 .. warning:: For Django<2.2, django CMS<3.7 versions support, use djangocms-blog 1.1x.
 
+.. warning:: Version 1.2 introduce a breaking change for customized ``BLOG_PERMALINK_URLS``.
+             Check the `permalinks`_ documentation for update information.
+
 ************
 Installation
 ************
@@ -53,6 +56,7 @@ See DjangoPackages for an updated list https://www.djangopackages.com/packages/p
 
 .. _features documentation: http://djangocms-blog.readthedocs.io/en/latest/features/
 .. _installation documentation: http://djangocms-blog.readthedocs.io/en/latest/installation.html
+.. _permalinks: http://djangocms-blog.readthedocs.io/en/latest/features/permalinks.html
 .. _cmsplugin-filer migration documentation: http://djangocms-blog.readthedocs.io/en/latest/cmsplugin_filer.html
 
 

--- a/changes/645.bugfix
+++ b/changes/645.bugfix
@@ -1,0 +1,1 @@
+BREAKING CHANGE: Replace url() function with path()

--- a/djangocms_blog/admin.py
+++ b/djangocms_blog/admin.py
@@ -5,14 +5,13 @@ from cms.admin.placeholderadmin import FrontendEditableAdminMixin, PlaceholderAd
 from cms.models import CMSPlugin, ValidationError
 from django.apps import apps
 from django.conf import settings
-from django.conf.urls import url
 from django.contrib import admin, messages
 from django.contrib.admin.options import InlineModelAdmin
 from django.contrib.sites.models import Site
 from django.db import models
 from django.db.models import signals
 from django.http import HttpResponseRedirect
-from django.urls import reverse
+from django.urls import path, reverse
 from django.utils import timezone
 from django.utils.translation import get_language_from_request, gettext_lazy as _, ngettext as __
 from parler.admin import TranslatableAdmin
@@ -283,8 +282,8 @@ class PostAdmin(PlaceholderAdminMixin, FrontendEditableAdminMixin, ModelAppHookC
         Customize the modeladmin urls
         """
         urls = [
-            url(
-                r"^publish/([0-9]+)/$",
+            path(
+                "publish/<int:pk>/$",
                 self.admin_site.admin_view(self.publish_post),
                 name="djangocms_blog_publish_article",
             ),

--- a/djangocms_blog/models.py
+++ b/djangocms_blog/models.py
@@ -362,19 +362,21 @@ class Post(KnockerModel, BlogMetaMixin, TranslatableModel):
             else:
                 current_date = self.date_created
             urlconf = get_setting("PERMALINK_URLS")[self.app_config.url_patterns]
-            if "<year>" in urlconf:
+            if "<int:year>" in urlconf:
                 kwargs["year"] = current_date.year
-            if "<month>" in urlconf:
+            if "<int:month>" in urlconf:
                 kwargs["month"] = "%02d" % current_date.month
-            if "<day>" in urlconf:
+            if "<int:day>" in urlconf:
                 kwargs["day"] = "%02d" % current_date.day
-            if "<slug>" in urlconf:
+            if "<slug:slug>" in urlconf:
                 kwargs["slug"] = self.safe_translation_getter("slug", language_code=lang, any_language=True)  # NOQA
-            if "<category>" in urlconf:
+            if "<slug:category>" in urlconf:
                 kwargs["category"] = category.safe_translation_getter(
                     "slug", language_code=lang, any_language=True
                 )  # NOQA
-            return reverse("%s:post-detail" % self.app_config.namespace, kwargs=kwargs)
+            return reverse(
+                "%s:post-detail" % self.app_config.namespace, kwargs=kwargs, current_app=self.app_config.namespace
+            )
 
     def get_title(self):
         title = self.safe_translation_getter("meta_title", any_language=True)

--- a/djangocms_blog/settings.py
+++ b/djangocms_blog/settings.py
@@ -35,10 +35,10 @@ Permalinks styles.
 """
 
 PERMALINKS_URLS = {  # noqa
-    PERMALINK_TYPE_FULL_DATE: r"^(?P<year>\d{4})/(?P<month>\d{1,2})/(?P<day>\d{1,2})/(?P<slug>\w[-\w]*)/$",
-    PERMALINK_TYPE_SHORT_DATE: r"^(?P<year>\d{4})/(?P<month>\d{1,2})/(?P<slug>\w[-\w]*)/$",
-    PERMALINK_TYPE_CATEGORY: r"^(?P<category>\w[-\w]*)/(?P<slug>\w[-\w]*)/$",
-    PERMALINK_TYPE_SLUG: r"^(?P<slug>\w[-\w]*)/$",
+    PERMALINK_TYPE_FULL_DATE: "<int:year>/<int:month>/<int:day>/<slug:slug>/",
+    PERMALINK_TYPE_SHORT_DATE: "<int:year>/<int:month>/<slug:slug>/",
+    PERMALINK_TYPE_CATEGORY: "<slug:category>/<slug:slug>/",
+    PERMALINK_TYPE_SLUG: "<slug:slug>/",
 }
 """
 .. _PERMALINKS_URLS:

--- a/djangocms_blog/taggit_urls.py
+++ b/djangocms_blog/taggit_urls.py
@@ -1,5 +1,7 @@
-from django.conf.urls import include, url
+# This file is used on divio cloud only during automatic setup
+from django.conf.urls import include  # pragma: no cover
+from django.urls import path  # pragma: no cover
 
-urlpatterns = [
-    url(r"^taggit_autosuggest/", include("taggit_autosuggest.urls")),
+urlpatterns = [  # pragma: no cover
+    path("taggit_autosuggest/", include("taggit_autosuggest.urls")),
 ]

--- a/djangocms_blog/urls.py
+++ b/djangocms_blog/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import path
 
 from .feeds import FBInstantArticles, LatestEntriesFeed, TagFeed
 from .settings import get_setting
@@ -17,7 +17,7 @@ def get_urls():
     details = []
     for urlconf in urls.values():
         details.append(
-            url(urlconf, PostDetailView.as_view(), name="post-detail"),
+            path(urlconf, PostDetailView.as_view(), name="post-detail"),
         )
     return details
 
@@ -27,13 +27,13 @@ detail_urls = get_urls()
 # module-level app_name attribute as per django 1.9+
 app_name = "djangocms_blog"
 urlpatterns = [
-    url(r"^$", PostListView.as_view(), name="posts-latest"),
-    url(r"^feed/$", LatestEntriesFeed(), name="posts-latest-feed"),
-    url(r"^feed/fb/$", FBInstantArticles(), name="posts-latest-feed-fb"),
-    url(r"^(?P<year>\d{4})/$", PostArchiveView.as_view(), name="posts-archive"),
-    url(r"^(?P<year>\d{4})/(?P<month>\d{1,2})/$", PostArchiveView.as_view(), name="posts-archive"),
-    url(r"^author/(?P<username>[\w\.@+-]+)/$", AuthorEntriesView.as_view(), name="posts-author"),
-    url(r"^category/(?P<category>[\w\.@+-]+)/$", CategoryEntriesView.as_view(), name="posts-category"),
-    url(r"^tag/(?P<tag>[-\w]+)/$", TaggedListView.as_view(), name="posts-tagged"),
-    url(r"^tag/(?P<tag>[-\w]+)/feed/$", TagFeed(), name="posts-tagged-feed"),
+    path("", PostListView.as_view(), name="posts-latest"),
+    path("feed/", LatestEntriesFeed(), name="posts-latest-feed"),
+    path("feed/fb/", FBInstantArticles(), name="posts-latest-feed-fb"),
+    path("<int:year>/", PostArchiveView.as_view(), name="posts-archive"),
+    path("<int:year>/<int:month>/", PostArchiveView.as_view(), name="posts-archive"),
+    path("author/<str:username>/", AuthorEntriesView.as_view(), name="posts-author"),
+    path("category/<slug:category>/", CategoryEntriesView.as_view(), name="posts-category"),
+    path("tag/<slug:tag>/", TaggedListView.as_view(), name="posts-tagged"),
+    path("tag/<slug:tag>/feed/", TagFeed(), name="posts-tagged-feed"),
 ] + detail_urls

--- a/docs/features/home.rst
+++ b/docs/features/home.rst
@@ -31,12 +31,16 @@ To avoid this add the following settings to you project:
         ('category', _('Category')),
     )
     BLOG_PERMALINK_URLS = {
-        'full_date': r'^(?P<year>\d{4})/(?P<month>\d{1,2})/(?P<day>\d{1,2})/(?P<slug>\w[-\w]*)/$',
-        'short_date': r'^(?P<year>\d{4})/(?P<month>\d{1,2})/(?P<slug>\w[-\w]*)/$',
-        'category': r'^(?P<category>\w[-\w]*)/(?P<slug>\w[-\w]*)/$',
+        "full_date": "<int:year>/<int:month>/<int:day>/<slug:slug>/",
+        "short_date: "<int:year>/<int:month>/<slug:slug>/",
+        "category": "<slug:category>/<slug:slug>/",
     }
 
 Notice that the last permalink type is no longer present.
 
 Then, pick any of the three remaining permalink types in the layout section of the apphooks config
 linked ot the home page (at http://yoursite.com/admin/djangocms_blog/blogconfig/).'
+
+.. warning:: Version 1.2 introduce a breaking change as it drops ``url`` function in favour of ``path``.
+             If you have customized the urls as documented above you **must** update the custom urlconf to path-based
+             patterns.

--- a/docs/features/permalinks.rst
+++ b/docs/features/permalinks.rst
@@ -20,10 +20,14 @@ like the following in the project settings:
 .. code-block:: python
 
     BLOG_PERMALINK_URLS = {
-        'full_date': r'^(?P<year>\d{4})/(?P<month>\d{1,2})/(?P<day>\d{1,2})/(?P<slug>\w[-\w]*)/$',
-        'short_date': r'^(?P<year>\d{4})/(?P<month>\d{1,2})/(?P<slug>\w[-\w]*)/$',
-        'category': r'^post/(?P<category>\w[-\w]*)/(?P<slug>\w[-\w]*)/$',
-        'slug': r'^post/(?P<slug>\w[-\w]*)/$',
+        "full_date": "<int:year>/<int:month>/<int:day>/<slug:slug>/",
+        "short_date: "<int:year>/<int:month>/<slug:slug>/",
+        "category": "<slug:category>/<slug:slug>/",
+        "slug": "<slug:slug>/",
     }
 
 And change ``post/`` with the desired prefix.
+
+.. warning:: Version 1.2 introduce a breaking change as it drops ``url`` function in favour of ``path``.
+             If you have customized the urls as documented above you **must** update the custom urlconf to path-based
+             patterns.

--- a/tests/test_utils/blog_urls.py
+++ b/tests/test_utils/blog_urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import path
 
 from djangocms_blog.feeds import FBInstantArticles, LatestEntriesFeed, TagFeed
 from djangocms_blog.settings import get_setting
@@ -17,7 +17,7 @@ def get_urls():
     details = []
     for urlconf in urls.values():
         details.append(
-            url(urlconf, PostDetailView.as_view(), name="post-detail"),
+            path(urlconf, PostDetailView.as_view(), name="post-detail"),
         )
     return details
 
@@ -25,13 +25,13 @@ def get_urls():
 detail_urls = get_urls()
 
 urlpatterns = [
-    url(r"^latests/$", PostListView.as_view(), name="posts-latest"),
-    url(r"^feed/$", LatestEntriesFeed(), name="posts-latest-feed"),
-    url(r"^feed/fb/$", FBInstantArticles(), name="posts-latest-feed-fb"),
-    url(r"^(?P<year>\d{4})/$", PostArchiveView.as_view(), name="posts-archive"),
-    url(r"^(?P<year>\d{4})/(?P<month>\d{1,2})/$", PostArchiveView.as_view(), name="posts-archive"),
-    url(r"^author/(?P<username>[\w\.@+-]+)/$", AuthorEntriesView.as_view(), name="posts-author"),
-    url(r"^category/(?P<category>[\w\.@+-]+)/$", CategoryEntriesView.as_view(), name="posts-category"),
-    url(r"^tag/(?P<tag>[-\w]+)/$", TaggedListView.as_view(), name="posts-tagged"),
-    url(r"^tag/(?P<tag>[-\w]+)/feed/$", TagFeed(), name="posts-tagged-feed"),
+    path("latests/", PostListView.as_view(), name="posts-latest"),
+    path("feed/", LatestEntriesFeed(), name="posts-latest-feed"),
+    path("feed/fb/", FBInstantArticles(), name="posts-latest-feed-fb"),
+    path("<int:year>/", PostArchiveView.as_view(), name="posts-archive"),
+    path("<int:year>/<int:month>/", PostArchiveView.as_view(), name="posts-archive"),
+    path("author/<str:username>/", AuthorEntriesView.as_view(), name="posts-author"),
+    path("category/<slug:category>/", CategoryEntriesView.as_view(), name="posts-category"),
+    path("tag/<slug:tag>/", TaggedListView.as_view(), name="posts-tagged"),
+    path("tag/<slug:tag>/feed/", TagFeed(), name="posts-tagged-feed"),
 ] + detail_urls


### PR DESCRIPTION
# Description

Time to drop url()-based urlconf definition and use path()

This will break installations with customized `BLOG_PERMALINK_URLS` setting, upgrade documentation added

## References

Fix #645 

# Checklist

* [x] I have read the [contribution guide](https://djangocms-blog.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://djangocms-blog.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [x] Usage documentation added in case of new features
* [x] Tests added
