### PR TITLE
Fix extra char in admin custom urlconf

### DIFF
--- a/changes/648.bugfix
+++ b/changes/648.bugfix
@@ -1,0 +1,1 @@
+Fix admin urlconf not matching path syntax

--- a/djangocms_blog/admin.py
+++ b/djangocms_blog/admin.py
@@ -283,7 +283,7 @@ class PostAdmin(PlaceholderAdminMixin, FrontendEditableAdminMixin, ModelAppHookC
         """
         urls = [
             path(
-                "publish/<int:pk>/$",
+                "publish/<int:pk>/",
                 self.admin_site.admin_view(self.publish_post),
                 name="djangocms_blog_publish_article",
             ),

--- a/djangocms_blog/models.py
+++ b/djangocms_blog/models.py
@@ -40,7 +40,7 @@ thumbnail_model = "{}.{}".format(ThumbnailOption._meta.app_label, ThumbnailOptio
 
 try:
     from knocker.mixins import KnockerModel
-except ImportError:
+except ImportError:  # pragma: no cover
 
     class KnockerModel:
         """
@@ -73,7 +73,6 @@ class BlogMetaMixin(ModelMeta):
         Retrieves django-meta attributes from apphook config instance
         :param param: django-meta attribute passed as key
         """
-        print(param, getattr(self.app_config, param))
         return self._get_meta_value(param, getattr(self.app_config, param)) or ""
 
     def get_locale(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -688,6 +688,20 @@ class AdminTest(BaseTest):
                     modified_post = Post.objects.language("en").get(pk=post.pk)
                     self.assertEqual(modified_post.safe_translation_getter("post_text"), data["post_text"])
 
+    def test_admin_publish_post_view(self):
+        self.get_pages()
+        post = self._get_post(self._post_data[0]["en"])
+
+        with pause_knocks(post):
+            post.publish = False
+            post.save()
+            self.client.force_login(self.user)
+            response = self.client.post(reverse("admin:djangocms_blog_publish_article", args=(post.pk,)))
+            self.assertEqual(response.status_code, 302)
+            self.assertEqual(response["Location"], post.get_absolute_url())
+            post.refresh_from_db()
+            self.assertTrue(post.publish)
+
     def test_admin_site(self):
         pages = self.get_pages()
         post = self._get_post(self._post_data[0]["en"])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -697,9 +697,9 @@ class AdminTest(BaseTest):
             post.save()
             self.client.force_login(self.user)
             response = self.client.post(reverse("admin:djangocms_blog_publish_article", args=(post.pk,)))
+            post.refresh_from_db()
             self.assertEqual(response.status_code, 302)
             self.assertEqual(response["Location"], post.get_absolute_url())
-            post.refresh_from_db()
             self.assertTrue(post.publish)
 
     def test_admin_site(self):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,11 +1,13 @@
 import os.path
 
 from aldryn_apphooks_config.utils import get_app_instance
+from app_helper.utils import captured_output
 from cms.api import add_plugin
 from cms.toolbar.items import ModalItem
 from cms.utils.apphook_reload import reload_urlconf
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ImproperlyConfigured
+from django.core.management import call_command
 from django.http import Http404
 from django.test import override_settings
 from django.urls import reverse
@@ -39,8 +41,21 @@ class CustomUrlViewTest(BaseTest):
         self.get_request(pages[1], "en", AnonymousUser())
         self.assertEqual(reverse("sample_app:posts-latest"), "/en/page-two/latests/")
 
+    @override_settings(BLOG_URLCONF="tests.test_utils.blog_urls")
+    def test_check_custom_urlconf(self):
+        """No django check fails with custom urlconf."""
+        with captured_output() as (out, err):
+            call_command("check", fail_level="DEBUG")
+        self.assertEqual(out.getvalue().strip(), "System check identified no issues (0 silenced).")
+
 
 class ViewTest(BaseTest):
+    def test_check_plain_urlconf(self):
+        """No django check fails with plain urlconf."""
+        with captured_output() as (out, err):
+            call_command("check", fail_level="DEBUG")
+        self.assertEqual(out.getvalue().strip(), "System check identified no issues (0 silenced).")
+
     def test_post_list_view_base_urlconf(self):
         pages = self.get_pages()
         self.get_posts()


### PR DESCRIPTION
# Description

Fix extra trailing `$` in publish admin view urlconf

Django is smart enough to ignore it, so the view continues to work

## References

Fix #648 
Fix #649 

# Checklist

* [x] I have read the [contribution guide](https://djangocms-blog.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://djangocms-blog.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [x] Usage documentation added in case of new features
* [x] Tests added
