### PR TITLE
FIX: Unicode chars in urls

### DIFF
--- a/changes/653.bugfix
+++ b/changes/653.bugfix
@@ -1,0 +1,1 @@
+Handle unicode chars in reverse of Post and Category models, using Django path() method instead of url()

--- a/djangocms_blog/models.py
+++ b/djangocms_blog/models.py
@@ -367,9 +367,9 @@ class Post(KnockerModel, BlogMetaMixin, TranslatableModel):
                 kwargs["month"] = "%02d" % current_date.month
             if "<int:day>" in urlconf:
                 kwargs["day"] = "%02d" % current_date.day
-            if "<slug:slug>" in urlconf:
+            if "<str:slug>" in urlconf or "<slug:slug>" in urlconf:
                 kwargs["slug"] = self.safe_translation_getter("slug", language_code=lang, any_language=True)  # NOQA
-            if "<slug:category>" in urlconf:
+            if "<slug:category>" in urlconf or "<str:category>" in urlconf:
                 kwargs["category"] = category.safe_translation_getter(
                     "slug", language_code=lang, any_language=True
                 )  # NOQA

--- a/djangocms_blog/settings.py
+++ b/djangocms_blog/settings.py
@@ -35,11 +35,12 @@ Permalinks styles.
 """
 
 PERMALINKS_URLS = {  # noqa
-    PERMALINK_TYPE_FULL_DATE: "<int:year>/<int:month>/<int:day>/<slug:slug>/",
-    PERMALINK_TYPE_SHORT_DATE: "<int:year>/<int:month>/<slug:slug>/",
-    PERMALINK_TYPE_CATEGORY: "<slug:category>/<slug:slug>/",
-    PERMALINK_TYPE_SLUG: "<slug:slug>/",
+    PERMALINK_TYPE_FULL_DATE: "<int:year>/<int:month>/<int:day>/<str:slug>/",
+    PERMALINK_TYPE_SHORT_DATE: "<int:year>/<int:month>/<str:slug>/",
+    PERMALINK_TYPE_CATEGORY: "<str:category>/<str:slug>/",
+    PERMALINK_TYPE_SLUG: "<str:slug>/",
 }
+
 """
 .. _PERMALINKS_URLS:
 

--- a/djangocms_blog/urls.py
+++ b/djangocms_blog/urls.py
@@ -33,7 +33,7 @@ urlpatterns = [
     path("<int:year>/", PostArchiveView.as_view(), name="posts-archive"),
     path("<int:year>/<int:month>/", PostArchiveView.as_view(), name="posts-archive"),
     path("author/<str:username>/", AuthorEntriesView.as_view(), name="posts-author"),
-    path("category/<slug:category>/", CategoryEntriesView.as_view(), name="posts-category"),
+    path("category/<str:category>/", CategoryEntriesView.as_view(), name="posts-category"),
     path("tag/<slug:tag>/", TaggedListView.as_view(), name="posts-tagged"),
     path("tag/<slug:tag>/feed/", TagFeed(), name="posts-tagged-feed"),
 ] + detail_urls

--- a/docs/features/home.rst
+++ b/docs/features/home.rst
@@ -31,9 +31,9 @@ To avoid this add the following settings to you project:
         ('category', _('Category')),
     )
     BLOG_PERMALINK_URLS = {
-        "full_date": "<int:year>/<int:month>/<int:day>/<slug:slug>/",
-        "short_date: "<int:year>/<int:month>/<slug:slug>/",
-        "category": "<slug:category>/<slug:slug>/",
+        "full_date": "<int:year>/<int:month>/<int:day>/<str:slug>/",
+        "short_date: "<int:year>/<int:month>/<str:slug>/",
+        "category": "<str:category>/<str:slug>/",
     }
 
 Notice that the last permalink type is no longer present.

--- a/docs/features/permalinks.rst
+++ b/docs/features/permalinks.rst
@@ -20,10 +20,10 @@ like the following in the project settings:
 .. code-block:: python
 
     BLOG_PERMALINK_URLS = {
-        "full_date": "<int:year>/<int:month>/<int:day>/<slug:slug>/",
-        "short_date: "<int:year>/<int:month>/<slug:slug>/",
-        "category": "<slug:category>/<slug:slug>/",
-        "slug": "<slug:slug>/",
+        "full_date": "<int:year>/<int:month>/<int:day>/<str:slug>/",
+        "short_date: "<int:year>/<int:month>/<str:slug>/",
+        "category": "<str:category>/<str:slug>/",
+        "slug": "<str:slug>/",
     }
 
 And change ``post/`` with the desired prefix.

--- a/tests/test_utils/blog_urls.py
+++ b/tests/test_utils/blog_urls.py
@@ -31,7 +31,7 @@ urlpatterns = [
     path("<int:year>/", PostArchiveView.as_view(), name="posts-archive"),
     path("<int:year>/<int:month>/", PostArchiveView.as_view(), name="posts-archive"),
     path("author/<str:username>/", AuthorEntriesView.as_view(), name="posts-author"),
-    path("category/<slug:category>/", CategoryEntriesView.as_view(), name="posts-category"),
+    path("category/<str:category>/", CategoryEntriesView.as_view(), name="posts-category"),
     path("tag/<slug:tag>/", TaggedListView.as_view(), name="posts-tagged"),
     path("tag/<slug:tag>/feed/", TagFeed(), name="posts-tagged-feed"),
 ] + detail_urls


### PR DESCRIPTION
Handle unicode chars in reverse of Post and Category models, using Django path() method instead of url()

Closes #653

# Description

Allow to reverse blog Post and Category models urls using the Django path method instead of url.
A bug appeared in v1.2.0 when migrating from url() to path() when resolving slugs with unicode chars as Django path converters only accepts ASCII letters or numbers, plus the hyphen and underscore characters and no unicode chars.

I suggest to use an str path instead of a slug path for urls to reverse properly.

## References

* The Django path converters documentation: https://docs.djangoproject.com/fr/3.1/topics/http/urls/#path-converters
* An issue describing the bug: https://github.com/nephila/djangocms-blog/issues/653


Provide any github issue fixed (as in ``Fix #XYZ``)

# Checklist

* [x] I have read the [contribution guide](https://djangocms-blog.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://djangocms-blog.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [x] Usage documentation added in case of new features
* [x] Tests added
