### PR TITLE
Add support for Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ jobs:
         python-version: [3.9, 3.8, 3.7, 3.6]
         django: [31, 30, 22]
         cms: [38, 37]
+        exclude:
+          - django: 31
+            cms: 37
         include:
           - python-version: 3.8
             django: 22

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,16 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.7, 3.6, 3.5]
+        python-version: [3.9, 3.8, 3.7, 3.6]
         django: [31, 30, 22]
         cms: [38, 37]
-        exclude:
-          - python-version: 3.5
-            django: 30
-          - python-version: 3.5
-            django: 31
-          - django: 31
-            cms: 37
         include:
           - python-version: 3.8
             django: 22

--- a/changes/657.feature
+++ b/changes/657.feature
@@ -1,0 +1,1 @@
+Add support for Python 3.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,10 +43,10 @@ classifiers =
 	Framework :: Django :: 3.1
 	Programming Language :: Python
 	Programming Language :: Python :: 3
-	Programming Language :: Python :: 3.5
 	Programming Language :: Python :: 3.6
 	Programming Language :: Python :: 3.7
 	Programming Language :: Python :: 3.8
+	Programming Language :: Python :: 3.9
 
 [options]
 include_package_data = True

--- a/tests/base.py
+++ b/tests/base.py
@@ -6,8 +6,6 @@ from app_helper.base_test import BaseTestCase
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.core.cache import cache
-from haystack import connections
-from haystack.constants import DEFAULT_ALIAS
 from menus.menu_pool import menu_pool
 from parler.utils.context import smart_override
 
@@ -257,6 +255,9 @@ class BaseTest(BaseTestCase):
         return posts
 
     def get_post_index(self):
+        from haystack import connections
+        from haystack.constants import DEFAULT_ALIAS
+
         search_conn = connections[DEFAULT_ALIAS]
         unified_index = search_conn.get_unified_index()
         index = unified_index.get_index(Post)

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -2,8 +2,6 @@ from unittest import skipIf
 
 from cms.api import add_plugin
 from django.test import override_settings
-from haystack.constants import DEFAULT_ALIAS
-from haystack.query import SearchQuerySet
 
 from djangocms_blog.models import Post
 
@@ -14,6 +12,13 @@ try:
 except ImportError:
     aldryn_search = None
 
+try:
+    import haystack
+    from haystack.constants import DEFAULT_ALIAS
+    from haystack.query import SearchQuerySet
+except ImportError:
+    haystack = None
+
 
 class BlogIndexingTests(BaseTest):
     sample_text = "First post first line This is the description keyword1  keyword2 category 1 a tag test body"
@@ -22,6 +27,7 @@ class BlogIndexingTests(BaseTest):
         self.get_pages()
 
     @skipIf(aldryn_search is None, "aldryn-search not installed")
+    @skipIf(haystack is None, "haystack not installed")
     def test_blog_post_is_indexed_using_prepare(self):
         """This tests the indexing path way used by update_index mgmt command"""
         post = self._get_post(self._post_data[0]["en"])
@@ -41,6 +47,7 @@ class BlogIndexingTests(BaseTest):
         self.assertEqual(post.date_published, indexed["pub_date"])
 
     @skipIf(aldryn_search is None, "aldryn-search not installed")
+    @skipIf(haystack is None, "haystack not installed")
     @override_settings(BLOG_USE_PLACEHOLDER=False)
     def test_blog_post_is_indexed_using_prepare_no_placeholder(self):
         """This tests the indexing path way used by update_index mgmt command when not using placeholder content"""
@@ -62,6 +69,7 @@ class BlogIndexingTests(BaseTest):
         self.assertEqual(post.get_absolute_url(), indexed["url"])
         self.assertEqual(post.date_published, indexed["pub_date"])
 
+    @skipIf(haystack is None, "haystack not installed")
     def test_searchqueryset(self):
         posts = self.get_posts()
         all_results = SearchQuerySet().models(Post)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1061,7 +1061,10 @@ class ModelsTest(BaseTest):
         post.app_config = self.app_config_1
 
         self.assertTrue(
-            re.match(r".*{}/{}/$".format(urlquote(post.categories.first().slug), urlquote(post.slug)), post.get_absolute_url())
+            re.match(
+                r".*{}/{}/$".format(urlquote(post.categories.first().slug), urlquote(post.slug)),
+                post.get_absolute_url(),
+            )
         )
 
         # slug only

--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,9 @@ envlist =
     pep8
     pypi-description
     towncrier
-    py{38,37,36}-django{31}-cms{38,no-search-38}
-    py{38,37,36}-django{30}-cms{38,37,no-search-37}
-    py{38,37,36,35}-django{22}-cms{38,37,no-search-37}
+    py{39,38,37,36}-django{31}-cms{38,no-search-38}
+    py{39,38,37,36}-django{30}-cms{38,37,no-search-37}
+    py{39,38,37,36,35}-django{22}-cms{38,37,no-search-37}
 
 [testenv]
 commands = {env:COMMAND:python} cms_helper.py djangocms_blog test {posargs}
@@ -19,22 +19,21 @@ deps =
     django22: django-mptt>=0.8
     django22: django-filer>=1.5,<1.6
     django22: django-appdata>=0.2.2
-    django22: django-haystack
     django30: Django>=3.0,<3.1
     django30: django-mptt>=0.9
     django30: django-filer>=1.6
     django30: django-appdata>=0.3.0
-    django30: django-haystack==3.0b2
     django31: Django>=3.1,<3.2
     django31: django-mptt>=0.9
     django31: django-filer>=2.0
     django31: django-appdata>=0.3.2
-    django31: django-haystack==3.0b2
     cms37: https://github.com/divio/django-cms/archive/release/3.7.x.zip
     cms37: aldryn-search
+    cms37: django-haystack==3.0b2
     cms-no-search-37: https://github.com/divio/django-cms/archive/release/3.7.x.zip
     cms38: https://github.com/divio/django-cms/archive/release/3.8.x.zip
     cms38: aldryn-search
+    cms38: django-haystack==3.0b2
     cms-no-search-38: https://github.com/divio/django-cms/archive/release/3.8.x.zip
     channels>2,<3
     https://github.com/nephila/django-knocker/archive/master.zip


### PR DESCRIPTION
# Description

* Add support for Python 3.9
* Move haystack tox dependency only when testing with search features
* Drop python 3.5 from CI

## References

Fix #657 

# Checklist

* [x] I have read the [contribution guide](https://djangocms-blog.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://djangocms-blog.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [x] Usage documentation added in case of new features
* [ ] Tests added
