### PR TITLE
Add a CMS toolbar item for category and tag list

### DIFF
--- a/djangocms_blog/cms_toolbars.py
+++ b/djangocms_blog/cms_toolbars.py
@@ -18,6 +18,13 @@ class BlogToolbar(CMSToolbar):
         with override(self.current_lang):
             url = reverse("admin:djangocms_blog_post_changelist")
             admin_menu.add_modal_item(_("Post list"), url=url)
+
+            url = reverse("admin:djangocms_blog_blogcategory_changelist")
+            admin_menu.add_modal_item(_("Category list"), url=url)
+
+            url = reverse("admin:taggit_tag_changelist")
+            admin_menu.add_modal_item(_("Tag list"), url=url)
+
             url = reverse("admin:djangocms_blog_post_add")
             admin_menu.add_modal_item(_("Add post"), url=url)
             current_config = getattr(self.request, get_setting("CURRENT_NAMESPACE"), None)

--- a/tests/test_toolbar.py
+++ b/tests/test_toolbar.py
@@ -27,6 +27,11 @@ class ToolbarTest(BaseTest):
         toolbar.get_left_items()
         blog_menu = toolbar.menus["djangocms_blog"]
         self.assertEqual(len(blog_menu.find_items(ModalItem, url=reverse("admin:djangocms_blog_post_changelist"))), 1)
+        self.assertEqual(
+            len(blog_menu.find_items(ModalItem, url=reverse("admin:djangocms_blog_blogcategory_changelist"))),
+            1,
+        )
+        self.assertEqual(len(blog_menu.find_items(ModalItem, url=reverse("admin:taggit_tag_changelist"))), 1)
         self.assertEqual(len(blog_menu.find_items(ModalItem, url=reverse("admin:djangocms_blog_post_add"))), 1)
         self.assertEqual(
             len(blog_menu.find_items(ModalItem, url=reverse("admin:djangocms_blog_post_change", args=(posts[0].pk,)))),


### PR DESCRIPTION
# Description

Add links on the Blog toolbar menu, to manage BlogCategory and Tag, without visiting django admin site.

# Checklist

* [x] I have read the [contribution guide](https://djangocms-blog.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://djangocms-blog.readthedocs.io/en/latest/contributing.html#pull-request-guidelines)) --> no issue number
* [x] Usage documentation added in case of new features --> not needed
* [x] Tests added
