### PR TITLE
Avoid possible migration failure

### DIFF
--- a/djangocms_blog/migrations/0001_initial.py
+++ b/djangocms_blog/migrations/0001_initial.py
@@ -18,7 +18,7 @@ class Migration(migrations.Migration):
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         migrations.swappable_dependency(ACTUAL_FILER_IMAGE_MODEL),
-        ("cms", "__first__"),
+        ("cms", "__latest__"),
         ("taggit", "__first__"),
         ("filer", "0003_thumbnailoption"),
     ]


### PR DESCRIPTION
Django migrations are applied in random order unless a dependency is specified. This file specifies dependency to the first migration of the cms module, however it also requires the cms.Placeholder model which is only defined in subsequent migration files of the cms module. This means that if Django decides to only apply the first migration of the cms module, followed by the first migration of the djangocms_blog module (which is valid since there are no further dependencies), the migration process will fail because cms.CMSPlugin has not been created yet. This happens in my project all the time. The proposed change ensures that all cms migrations are finished before djangocms_blog migrations start, hence enabling the migration process to succeed.
