### PR TITLE
Remove escape for meta description.

### DIFF
--- a/changes/699.bugfix
+++ b/changes/699.bugfix
@@ -1,0 +1,1 @@
+See description here: https://github.com/nephila/djangocms-blog/issues/699

--- a/djangocms_blog/models.py
+++ b/djangocms_blog/models.py
@@ -14,7 +14,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.encoding import force_bytes, force_str
 from django.utils.functional import cached_property
-from django.utils.html import escape, strip_tags
+from django.utils.html import strip_tags
 from django.utils.translation import get_language, gettext, gettext_lazy as _
 from djangocms_text_ckeditor.fields import HTMLField
 from filer.fields.image import FilerImageField
@@ -182,7 +182,7 @@ class BlogCategory(BlogMetaMixin, TranslatableModel):
 
     def get_description(self):
         description = self.safe_translation_getter("meta_description", any_language=True)
-        return escape(strip_tags(description)).strip()
+        return strip_tags(description).strip()
 
 
 class Post(KnockerModel, BlogMetaMixin, TranslatableModel):
@@ -394,7 +394,7 @@ class Post(KnockerModel, BlogMetaMixin, TranslatableModel):
         description = self.safe_translation_getter("meta_description", any_language=True)
         if not description:
             description = self.safe_translation_getter("abstract", any_language=True)
-        return escape(strip_tags(description)).strip()
+        return strip_tags(description).strip()
 
     def get_image_full_url(self):
         if self.main_image:


### PR DESCRIPTION
This is not required since all meta tags are escaped in django-meta.

# Description

See description of [corresponding issue](https://github.com/nephila/djangocms-blog/issues/699).

## References

Fix #699

# Checklist

* [x] I have read the [contribution guide](https://djangocms-blog.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
    ```
    __ summary __
    pep8: commands succeeded
    isort: commands succeeded
    black: commands succeeded
    pypi-description: commands succeeded
    congratulations :)
    ```
* [x] ``changes`` file included (see [docs](https://djangocms-blog.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] ~Usage documentation added in case of new features~
* [ ] ~Tests added~
