### PR TITLE
doc/add-blog_auto_namespace-setting

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -77,6 +77,8 @@ Global Settings
   (default: ``Blog``)
 * BLOG_AUTO_APP_TITLE: Title of the ``BlogConfig`` instance created by
   **Auto setup**; (default: ``Blog``)
+* BLOG_AUTO_NAMESPACE: Instance namespace of the ``BlogConfig`` instance created by
+  **Auto setup**; (default: ``Blog``)
 * BLOG_SITEMAP_PRIORITY_DEFAULT: Default priority for sitemap items; (default: ``0.5``)
 * BLOG_SITEMAP_CHANGEFREQ: List for available changefreqs for sitemap items; (default: **always**,
   **hourly**, **daily**, **weekly**, **monthly**, **yearly**, **never**)


### PR DESCRIPTION
# Description

Add missing setting to relevant doc.

> __To what base should this PR point?__
> I only tested this setting on 1.1.1, so I am currently only comfortable suggesting the change for 1.1.1.

Describe:

* Add `BLOG_AUTO_NAMESPACE` to global settings doc
* Fixes inability of user to set "INSTANCE NAMESPACE" after auto setup.

## References

N/A

# Checklist

* [x] I have read the [contribution guide](https://djangocms-blog.readthedocs.io/en/latest/contributing.html)
* [ ] Code lint checked via `inv lint`
* [ ] ``changes`` file included (see [docs](https://djangocms-blog.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [ ] Tests added
