### PR TITLE
Add new setting: disable unicode in slugs.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.6.0
     hooks:
       - id: black
   - repo: https://gitlab.com/pycqa/flake8

--- a/changes/707.feature
+++ b/changes/707.feature
@@ -1,0 +1,1 @@
+Add optional BLOG_UNICODE_SLUGS setting that disable unicode in blog posts slugs.

--- a/djangocms_blog/fields.py
+++ b/djangocms_blog/fields.py
@@ -1,7 +1,9 @@
 from django.utils.text import slugify as django_slugify
 
+from .settings import get_setting
+
 __all__ = ["slugify"]
 
 
 def slugify(base):
-    return django_slugify(base, allow_unicode=True)
+    return django_slugify(base, allow_unicode=get_setting("UNICODE_SLUGS"))

--- a/djangocms_blog/models.py
+++ b/djangocms_blog/models.py
@@ -248,7 +248,9 @@ class Post(KnockerModel, BlogMetaMixin, TranslatableModel):
 
     translations = TranslatedFields(
         title=models.CharField(_("title"), max_length=752),
-        slug=models.SlugField(_("slug"), max_length=752, blank=True, db_index=True, allow_unicode=True),
+        slug=models.SlugField(
+            _("slug"), max_length=752, blank=True, db_index=True, allow_unicode=get_setting("UNICODE_SLUGS")
+        ),
         subtitle=models.CharField(verbose_name=_("subtitle"), max_length=767, blank=True, default=""),
         abstract=HTMLField(_("abstract"), blank=True, default="", configuration="BLOG_ABSTRACT_CKEDITOR"),
         meta_description=models.TextField(verbose_name=_("post meta description"), blank=True, default=""),

--- a/djangocms_blog/settings.py
+++ b/djangocms_blog/settings.py
@@ -34,6 +34,14 @@ PERMALINKS = (  # noqa
 Permalinks styles.
 """
 
+BLOG_UNICODE_SLUGS = True
+"""
+.. _UNICODE_SLUGS:
+
+Allow unicode chars in auto-generated slugs.
+"""
+
+
 PERMALINKS_URLS = {  # noqa
     PERMALINK_TYPE_FULL_DATE: "<int:year>/<int:month>/<int:day>/<str:slug>/",
     PERMALINK_TYPE_SHORT_DATE: "<int:year>/<int:month>/<str:slug>/",


### PR DESCRIPTION
# Description

Add optional `BLOG_UNICODE_SLUGS` setting (default is still allow_unicode=True when generating a slug).

Update black version in .pre-commit-config.yaml in order to make this commit.

## References

Fix #707.

# Checklist

* [x] I have read the [contribution guide](https://djangocms-blog.readthedocs.io/en/latest/contributing.html)
* [ ] Code lint checked via `inv lint`
  * never seen the end of the command, seems to output errors for hours, may be broken ?
* [x] ``changes`` file included (see [docs](https://djangocms-blog.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [x] Usage documentation added in case of new features
  * added a simple setting var, should be auto-added in the doc during build
* [ ] Tests added
  * may add a test later when I have more time + when all the tests will be fixed
