### PR TITLE
fix(templates): blog_meta category & tag classname (B)

### DIFF
--- a/djangocms_blog/templates/djangocms_blog/includes/blog_meta.html
+++ b/djangocms_blog/templates/djangocms_blog/includes/blog_meta.html
@@ -21,13 +21,13 @@
     {% if post.categories.exists %}
         {% for category in post.categories.all %}
             {% if category.slug %}
-                <li class="category_{{ forloop.counter }}"><a href="{% url 'djangocms_blog:posts-category' category=category.slug %}" class="blog-categories-{{ category.count }}">{{ category.name }}</a>{% if not forloop.last %}, {% endif %}</li>
+                <li class="category_{{ forloop.counter }}"><a href="{% url 'djangocms_blog:posts-category' category=category.slug %}" class="blog-categories-{{ forloop.counter }}">{{ category.name }}</a>{% if not forloop.last %}, {% endif %}</li>
             {% endif %}
         {% endfor %}
     {% endif %}
     {% if post.tags.exists %}
         {% for tag in post.tags.all %}
-            <li class="tag_{{ forloop.counter }}"><a href="{% url 'djangocms_blog:posts-tagged' tag=tag.slug %}" class="blog-tag blog-tag-{{ tag.count }}">{{ tag.name }}</a>{% if not forloop.last %}, {% endif %}</li>
+            <li class="tag_{{ forloop.counter }}"><a href="{% url 'djangocms_blog:posts-tagged' tag=tag.slug %}" class="blog-tag blog-tag-{{ forloop.counter }}">{{ tag.name }}</a>{% if not forloop.last %}, {% endif %}</li>
         {% endfor %}
     {% endif %}
 </ul>


### PR DESCRIPTION
# Description

Describe:

* Build classname with automated, required, recognizable "slug" instead of empty "count".
* Classname is `blog-categories-__FOR_LOOP_COUNT__` instead of `blog-categories-`.

## References

- fixes #710

# Checklist

* [x] I have read the [contribution guide](https://djangocms-blog.readthedocs.io/en/latest/contributing.html)
* [ ] Code lint checked via `inv lint`
* [ ] ``changes`` file included (see [docs](https://djangocms-blog.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [ ] Tests added
