### PR TITLE
Fix pre-commit flake8 repo url

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 exclude: "(.idea|node_modules|.tox)"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -17,15 +17,15 @@ repos:
         args:
           - --remove
   - repo: https://github.com/timothycrosley/isort
-    rev: "5.6.4"
+    rev: "5.12.0"
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 23.1.0
     hooks:
       - id: black
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+  - repo: https://github.com/PyCQA/flake8
+    rev: 5.0.4
     hooks:
       - id: flake8
         additional_dependencies:
@@ -40,14 +40,14 @@ repos:
           - flake8-tidy-imports
           - pep8-naming
   - repo: https://github.com/econchick/interrogate
-    rev: 1.3.1
+    rev: 1.5.0
     hooks:
       - id: interrogate
         args:
           - "-cpyproject.toml"
           - "--quiet"
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.7.3
+    rev: v3.3.1
     hooks:
       - id: pyupgrade
         args:

--- a/changes/715.bugfix
+++ b/changes/715.bugfix
@@ -1,0 +1,1 @@
+Fix pre-commit flake8 repo url


### PR DESCRIPTION
# Description

Fix pre-commit flake8 repo url and autoupdate module to their latest versions, except flake8 (5.0.4) because flake8-broken-line is not compatible with flake8 6.0.0

## References

Fix #715 

# Checklist

* [x] I have read the [contribution guide](https://djangocms-blog.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://djangocms-blog.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [ ] Tests added
