### PR TITLE
Improve meta image size handling

### DIFF
--- a/changes/718.feature
+++ b/changes/718.feature
@@ -1,0 +1,1 @@
+Improve meta image size handling

--- a/djangocms_blog/models.py
+++ b/djangocms_blog/models.py
@@ -17,6 +17,7 @@ from django.utils.functional import cached_property
 from django.utils.html import escape, strip_tags
 from django.utils.translation import get_language, gettext, gettext_lazy as _
 from djangocms_text_ckeditor.fields import HTMLField
+from easy_thumbnails.files import get_thumbnailer
 from filer.fields.image import FilerImageField
 from filer.models import ThumbnailOption
 from meta.models import ModelMeta
@@ -398,7 +399,9 @@ class Post(KnockerModel, BlogMetaMixin, TranslatableModel):
 
     def get_image_full_url(self):
         if self.main_image:
-            return self.build_absolute_uri(self.main_image.url)
+            options = get_setting("META_IMAGE_SIZE")
+            thumbnail_url = get_thumbnailer(self.main_image).get_thumbnail(options).url
+            return self.build_absolute_uri(thumbnail_url)
         return ""
 
     def get_image_width(self):

--- a/djangocms_blog/settings.py
+++ b/djangocms_blog/settings.py
@@ -90,6 +90,14 @@ Easy-thumbnail alias configuration for the post main image when shown on the pos
 it's a dictionary with ``size``, ``crop`` and ``upscale`` keys.
 """
 
+BLOG_META_IMAGE_SIZE = {"size": (1600, 1600), "crop": False, "upscale": False}
+"""
+.. _META_IMAGE_SIZE:
+
+Easy-thumbnail alias configuration for the post meta image;
+it's a dictionary with ``size``, ``crop`` and ``upscale`` keys.
+"""
+
 BLOG_URLCONF = "djangocms_blog.urls"
 """
 .. _URLCONF:


### PR DESCRIPTION
# Description

Use a thumbnailer on the meta image field, that uses a BLOG_META_IMAGE_SIZE thumbnail option setting with a default size of 1600x1600px (facebook recommended size)

## References

Fix #718

# Checklist

* [x] I have read the [contribution guide](https://djangocms-blog.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://djangocms-blog.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [x] Usage documentation added in case of new features
* [ ] Tests added
