### PR TITLE
Fix distinct preventing post delete from admin

### DIFF
--- a/changes/683.bugfix
+++ b/changes/683.bugfix
@@ -1,0 +1,1 @@
+Fix distinct preventing post delete from admin

--- a/djangocms_blog/admin.py
+++ b/djangocms_blog/admin.py
@@ -438,7 +438,7 @@ class PostAdmin(PlaceholderAdminMixin, FrontendEditableAdminMixin, ModelAppHookC
         if sites.exists():
             pks = list(sites.all().values_list("pk", flat=True))
             qs = qs.filter(sites__in=pks)
-        return qs
+        return super().get_queryset(request).filter(pk__in=qs.values_list("pk", flat=True))
 
     def save_related(self, request, form, formsets, change):
         if self.get_restricted_sites(request).exists():

--- a/djangocms_blog/admin.py
+++ b/djangocms_blog/admin.py
@@ -438,7 +438,7 @@ class PostAdmin(PlaceholderAdminMixin, FrontendEditableAdminMixin, ModelAppHookC
         if sites.exists():
             pks = list(sites.all().values_list("pk", flat=True))
             qs = qs.filter(sites__in=pks)
-        return qs.distinct()
+        return qs
 
     def save_related(self, request, form, formsets, change):
         if self.get_restricted_sites(request).exists():

--- a/djangocms_blog/admin.py
+++ b/djangocms_blog/admin.py
@@ -438,6 +438,8 @@ class PostAdmin(PlaceholderAdminMixin, FrontendEditableAdminMixin, ModelAppHookC
         if sites.exists():
             pks = list(sites.all().values_list("pk", flat=True))
             qs = qs.filter(sites__in=pks)
+        # can't use distinct here because it prevents deleting records, but we need a unique list of posts because
+        # filters can cause duplicates
         return super().get_queryset(request).filter(pk__in=qs.values_list("pk", flat=True))
 
     def save_related(self, request, form, formsets, change):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -203,6 +203,25 @@ class AdminTest(BaseTest):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response["Location"], "/")
 
+    def test_admin_post_delete(self):
+        self.get_pages()
+
+        post_admin = admin.site._registry[Post]
+        request = self.get_page_request("/", self.user, r"/en/blog/", edit=False)
+
+        post = self._get_post(self._post_data[0]["en"])
+        post = self._get_post(self._post_data[0]["it"], post, "it")
+
+        post_admin.delete_model(request, post)
+
+    def test_admin_post_delete_queryset(self):
+        self.get_pages()
+
+        post_admin = admin.site._registry[Post]
+        request = self.get_page_request("/", self.user, r"/en/blog/", edit=False)
+
+        post_admin.delete_queryset(request, post_admin.get_queryset(request))
+
     def test_admin_changelist_view(self):
         self.get_pages()
 


### PR DESCRIPTION
# Description

Unneeded `distinct` call in `PostAdmin.get_queryset` breaks post deletion under django 3.2+

## References

Fix #683 

# Checklist

* [x] I have read the [contribution guide](https://djangocms-blog.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://djangocms-blog.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [ ] Tests added
