### PR TITLE
Fix template urls not respecting namespaces

### DIFF
--- a/changes/723.bugfix
+++ b/changes/723.bugfix
@@ -1,0 +1,1 @@
+Fix template urls not respecting namespaces

--- a/djangocms_blog/templates/djangocms_blog/includes/blog_meta.html
+++ b/djangocms_blog/templates/djangocms_blog/includes/blog_meta.html
@@ -1,9 +1,9 @@
-{% load i18n easy_thumbnails_tags cms_tags %}
+{% load i18n easy_thumbnails_tags cms_tags apphooks_config_tags %}
 
 <ul class="post-detail">
     {% if post.author %}
     <li>
-        {% trans "by" %} <a href="{% url 'djangocms_blog:posts-author' post.author.get_username %}">{% if post.author.get_full_name %}{{ post.author.get_full_name }}{% else %}{{ post.author }}{% endif %}</a>
+        {% trans "by" %} <a href="{% namespace_url 'posts-author' post.author.get_username namespace=post.app_config.namespace %}">{% if post.author.get_full_name %}{{ post.author.get_full_name }}{% else %}{{ post.author }}{% endif %}</a>
     </li>
     {% endif %}
     {% if post.date_published %}
@@ -21,13 +21,13 @@
     {% if post.categories.exists %}
         {% for category in post.categories.all %}
             {% if category.slug %}
-                <li class="category_{{ forloop.counter }}"><a href="{% url 'djangocms_blog:posts-category' category=category.slug %}" class="blog-categories-{{ category.count }} blog-categories-{{ category.slug }}">{{ category.name }}</a>{% if not forloop.last %}, {% endif %}</li>
+                <li class="category_{{ forloop.counter }}"><a href="{% namespace_url 'posts-category' category=category.slug namespace=category.app_config.namespace %}" class="blog-categories-{{ category.count }} blog-categories-{{ category.slug }}">{{ category.name }}</a>{% if not forloop.last %}, {% endif %}</li>
             {% endif %}
         {% endfor %}
     {% endif %}
     {% if post.tags.exists %}
         {% for tag in post.tags.all %}
-            <li class="tag_{{ forloop.counter }}"><a href="{% url 'djangocms_blog:posts-tagged' tag=tag.slug %}" class="blog-tag blog-tag-{{ tag.count }} blog-tag-{{ tag.slug }}">{{ tag.name }}</a>{% if not forloop.last %}, {% endif %}</li>
+            <li class="tag_{{ forloop.counter }}"><a href="{% namespace_url 'posts-tagged' tag=tag.slug namespace=post.app_config.namespace %}" class="blog-tag blog-tag-{{ tag.count }} blog-tag-{{ tag.slug }}">{{ tag.name }}</a>{% if not forloop.last %}, {% endif %}</li>
         {% endfor %}
     {% endif %}
 </ul>

--- a/djangocms_blog/templates/djangocms_blog/plugins/archive.html
+++ b/djangocms_blog/templates/djangocms_blog/plugins/archive.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% spaceless %}
+{% load i18n apphooks_config_tags %}{% spaceless %}
 <div class="plugin plugin-blog">
     <h3>{% trans "Archive" %}</h3>
     {% regroup dates by date.year as years %}
@@ -6,11 +6,11 @@
     <ul class="blog-archive">
         {% for year in years %}
         <li{% if year.grouper == current_year %} class="active"{% endif %}>
-            <a href="{% url 'djangocms_blog:posts-archive' year=year.grouper %}">{{ year.grouper }}</a>
+            <a href="{% namespace_url 'posts-archive' year=year.grouper namespace=instance.app_config.namespace %}">{{ year.grouper }}</a>
             <ul>
                 {% for month in year.list %}
                 <li{% if year.grouper == current_year and month.date.month == current_month %} class="active"{% else %} class="month"{% endif %}>
-                    <a href="{% url 'djangocms_blog:posts-archive' year=year.grouper month=month.date|date:"n" %}">
+                    <a href="{% namespace_url 'posts-archive' year=year.grouper month=month.date|date:"n" namespace=instance.app_config.namespace %}">
                         {{ month.date|date:"F" }}
                         <span>(
                             {% if month.count > 0 %}

--- a/djangocms_blog/templates/djangocms_blog/plugins/authors.html
+++ b/djangocms_blog/templates/djangocms_blog/plugins/authors.html
@@ -1,9 +1,9 @@
-{% load i18n easy_thumbnails_tags %}{% spaceless %}
+{% load i18n easy_thumbnails_tags apphooks_config_tags %}{% spaceless %}
 <div class="plugin plugin-blog">
     <h3>{% trans "Authors" %}</h3>
     <ul class="blog-authors">
         {% for author in authors_list %}
-        <li><a href="{% url 'djangocms_blog:posts-author' author.get_username %}">
+        <li><a href="{% namespace_url 'posts-author' author.get_username namespace=instance.app_config.namespace %}">
             {{ author.get_full_name }}
             <span>(
                 {% if author.count > 0 %}

--- a/djangocms_blog/templates/djangocms_blog/plugins/tags.html
+++ b/djangocms_blog/templates/djangocms_blog/plugins/tags.html
@@ -1,9 +1,11 @@
-{% load i18n %}{% spaceless %}
+{% load i18n apphooks_config_tags %}
+
+{% spaceless %}
 <div class="plugin plugin-blog">
     <h3>{% trans "Tags" %}</h3>
     <ul class="blog-tags">
         {% for tag in tags %}
-            <li><a href="{% url 'djangocms_blog:posts-tagged' tag=tag.slug %}" class="blog-tag-{{ tag.count }}">
+            <li><a href="{% namespace_url 'posts-tagged' tag=tag.slug namespace=instance.app_config.namespace %}" class="blog-tag-{{ tag.count }}">
                 {{ tag.name }}
                 <span>(
                     {% if tag.count > 0 %}


### PR DESCRIPTION
# Description

Fix template urls not respecting namespaces:
Before that, all plugins were outputting wrong urls if two different configs were present, ignoring the app config selected in plugins.

## References

Fix #723 

# Checklist

* [x] I have read the [contribution guide](https://djangocms-blog.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://djangocms-blog.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [x] Tests added
