### PR TITLE
Add force_str to FeaturedPostsPlugin __str__ method

### DIFF
--- a/changes/780.bugfix
+++ b/changes/780.bugfix
@@ -1,0 +1,1 @@
+Add force_str to FeaturedPostsPlugin __str__ method

--- a/djangocms_blog/models.py
+++ b/djangocms_blog/models.py
@@ -605,7 +605,7 @@ class FeaturedPostsPlugin(BasePostPlugin):
     posts = SortedManyToManyField(Post, verbose_name=_("Featured posts"))
 
     def __str__(self):
-        return _("Featured posts")
+        return force_str(_("Featured posts"))
 
     def copy_relations(self, oldinstance):
         self.posts.set(oldinstance.posts.all())


### PR DESCRIPTION
# Description

Add force_str to FeaturedPostsPlugin __str__ method

## References

Fix #780 

# Checklist

* [x] I have read the [contribution guide](https://djangocms-blog.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://djangocms-blog.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [x] Usage documentation added in case of new features
* [ ] Tests added
