### PR TITLE
Fix FeaturedPostsPlugin get_posts method rendering all posts instead of selected ones

### DIFF
--- a/changes/781.bugfix
+++ b/changes/781.bugfix
@@ -1,0 +1,1 @@
+Fix FeaturedPostsPlugin get_posts method rendering all posts instead of selected ones

--- a/djangocms_blog/models.py
+++ b/djangocms_blog/models.py
@@ -611,11 +611,7 @@ class FeaturedPostsPlugin(BasePostPlugin):
         self.posts.set(oldinstance.posts.all())
 
     def get_posts(self, request, published_only=True):
-        # if self.posts.exists():
-        #     posts = self.post_queryset(request, published_only, selected_posts=self.posts.all())
-        # else:
-        #     posts = self.post_queryset(request, published_only)
-        posts = self.post_queryset(request, published_only)
+        posts = self.post_queryset(request, published_only, selected_posts=self.posts.all())
         return posts
 
 

--- a/djangocms_blog/models.py
+++ b/djangocms_blog/models.py
@@ -513,9 +513,9 @@ class BasePostPlugin(CMSPlugin):
             "translations", "categories", "categories__translations", "categories__app_config"
         )
 
-    def post_queryset(self, request=None, published_only=True):
+    def post_queryset(self, request=None, published_only=True, selected_posts=None):
         language = get_language()
-        posts = Post.objects
+        posts = Post.objects if not selected_posts else selected_posts
         if self.app_config:
             posts = posts.namespace(self.app_config.namespace)
         if self.current_site:
@@ -611,6 +611,10 @@ class FeaturedPostsPlugin(BasePostPlugin):
         self.posts.set(oldinstance.posts.all())
 
     def get_posts(self, request, published_only=True):
+        # if self.posts.exists():
+        #     posts = self.post_queryset(request, published_only, selected_posts=self.posts.all())
+        # else:
+        #     posts = self.post_queryset(request, published_only)
         posts = self.post_queryset(request, published_only)
         return posts
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1364,10 +1364,11 @@ class ModelsTest2(BaseTest):
         plugin = add_plugin(post1.content, "BlogFeaturedPostsPlugin", language="en", app_config=self.app_config_1)
         plugin.posts.add(post1, post2)
         self.assertEqual(len(plugin.get_posts(request)), 1)
-
         post2.publish = True
         post2.save()
         self.assertEqual(len(plugin.get_posts(request)), 2)
+        plugin.posts.remove(post2)
+        self.assertEqual(len(plugin.get_posts(request)), 1)
 
     def test_copy_plugin_featured_post(self):
         post1 = self._get_post(self._post_data[0]["en"])

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -145,13 +145,13 @@ class PluginTest(BaseTest):
         plugin_nocache = add_plugin(ph, "BlogFeaturedPostsPlugin", language="en", app_config=self.app_config_1)
         plugin_nocache.posts.add(posts[0])
         # FIXME: Investigate the correct number of queries expected here
-        with self.assertNumQueries(FuzzyInt(16, 17)):
+        with self.assertNumQueries(FuzzyInt(15, 17)):
             self.render_plugin(pages[0], "en", plugin_nocache)
 
-        with self.assertNumQueries(FuzzyInt(16, 17)):
+        with self.assertNumQueries(FuzzyInt(15, 17)):
             self.render_plugin(pages[0], "en", plugin)
 
-        with self.assertNumQueries(FuzzyInt(16, 17)):
+        with self.assertNumQueries(FuzzyInt(15, 17)):
             rendered = self.render_plugin(pages[0], "en", plugin)
 
         self.assertTrue(rendered.find("<p>first line</p>") > -1)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -182,7 +182,7 @@ class PluginTest(BaseTest):
         self.assertTrue(rendered.find(posts[0].get_absolute_url()) > -1)
         self.assertTrue(rendered.find(posts[1].get_absolute_url()) > -1)
         plugin.posts.remove(posts[1])
-        
+
         rendered = self.render_plugin(pages[0], "en", plugin, edit=True)
         self.assertTrue(rendered.find(posts[0].get_absolute_url()) > -1)
         self.assertFalse(rendered.find(posts[1].get_absolute_url()) > -1)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -145,13 +145,13 @@ class PluginTest(BaseTest):
         plugin_nocache = add_plugin(ph, "BlogFeaturedPostsPlugin", language="en", app_config=self.app_config_1)
         plugin_nocache.posts.add(posts[0])
         # FIXME: Investigate the correct number of queries expected here
-        with self.assertNumQueries(FuzzyInt(14, 15)):
+        with self.assertNumQueries(FuzzyInt(16, 17)):
             self.render_plugin(pages[0], "en", plugin_nocache)
 
-        with self.assertNumQueries(FuzzyInt(14, 15)):
+        with self.assertNumQueries(FuzzyInt(16, 17)):
             self.render_plugin(pages[0], "en", plugin)
 
-        with self.assertNumQueries(FuzzyInt(14, 15)):
+        with self.assertNumQueries(FuzzyInt(16, 17)):
             rendered = self.render_plugin(pages[0], "en", plugin)
 
         self.assertTrue(rendered.find("<p>first line</p>") > -1)
@@ -181,6 +181,11 @@ class PluginTest(BaseTest):
         self.assertTrue(rendered.find('<article id="post-second-post"') > -1)
         self.assertTrue(rendered.find(posts[0].get_absolute_url()) > -1)
         self.assertTrue(rendered.find(posts[1].get_absolute_url()) > -1)
+        plugin.posts.remove(posts[1])
+        
+        rendered = self.render_plugin(pages[0], "en", plugin, edit=True)
+        self.assertTrue(rendered.find(posts[0].get_absolute_url()) > -1)
+        self.assertFalse(rendered.find(posts[1].get_absolute_url()) > -1)
 
     def test_plugin_tags(self):
         pages = self.get_pages()


### PR DESCRIPTION
# Description

Fix FeaturedPostsPlugin get_posts method rendering all posts instead of selected ones

## References

Fix #781 

# Checklist

* [x] I have read the [contribution guide](https://djangocms-blog.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://djangocms-blog.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [x] Tests added
