### PR TITLE
fix: catch Resolver404 in blog menu when 404 page with menu is rendered

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,8 @@ jobs:
           ${{ runner.os }}-lint-${{ matrix.toxenv }}-
     - name: Install dependencies
       run: |
-        sudo apt-get install libcairo2-dev
+        sudo apt update
+        sudo apt install libcairo2-dev
         python -m pip install --upgrade pip setuptools tox>4
     - name: Test with tox
       if: ${{ matrix.toxenv != 'towncrier' || (!contains(github.event.head_commit.message, '[pre-commit.ci]') && !contains(github.event.pull_request.body, 'pre-commit.ci start')) }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,8 @@ jobs:
           ${{ runner.os }}-tox-${{ format('{{py{0}-django{1}-cms{2}}}', matrix.python-version, matrix.django, matrix.cms) }}-
     - name: Install dependencies
       run: |
-        sudo apt-get install gettext libcairo2-dev
+        sudo apt update
+        sudo apt install gettext libcairo2-dev
         python -m pip install --upgrade pip setuptools tox>4
     - name: Test with tox
       env:

--- a/changes/793.bugfix
+++ b/changes/793.bugfix
@@ -1,0 +1,1 @@
+Catch Resolver404 when blog menu is rendered in 404 pages

--- a/djangocms_blog/cms_menus.py
+++ b/djangocms_blog/cms_menus.py
@@ -4,7 +4,7 @@ from cms.apphook_pool import apphook_pool
 from cms.menu_bases import CMSAttachMenu
 from django.contrib.sites.shortcuts import get_current_site
 from django.db.models.signals import post_delete, post_save
-from django.urls import resolve
+from django.urls import Resolver404, resolve
 from django.utils.translation import get_language_from_request, gettext_lazy as _
 from menus.base import Modifier, NavigationNode
 from menus.menu_pool import menu_pool
@@ -148,7 +148,10 @@ class BlogNavModifier(Modifier):
             app = apphook_pool.get_apphook(request.current_page.application_urls)
 
         if app and app.app_config:
-            namespace = resolve(request.path).namespace
+            try:
+                namespace = resolve(request.path).namespace
+            except Resolver404:  # pragma: no cover
+                return nodes
             if not self._config.get(namespace, False):
                 self._config[namespace] = app.get_config(namespace)
             config = self._config[namespace]


### PR DESCRIPTION
# Description

Catch Resolver404 in blog menu when 404 page with menu is rendered

## References

Fixe #793 

# Checklist

* [x] I have read the [contribution guide](https://djangocms-blog.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://djangocms-blog.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [ ] Tests added
