### PR TITLE
feat: make BlogFeaturedPostsPlugin show unpublished posts if in edit …

### DIFF
--- a/changes/850.feature
+++ b/changes/850.feature
@@ -1,0 +1,1 @@
+Make BlogFeaturedPostsPlugin show unpublished posts if in edit mode

--- a/djangocms_blog/cms_plugins.py
+++ b/djangocms_blog/cms_plugins.py
@@ -102,7 +102,7 @@ class BlogFeaturedPostsPlugin(BlogPlugin):
     def render(self, context, instance, placeholder):
         """Render the plugin."""
         context = super().render(context, instance, placeholder)
-        context["posts_list"] = instance.get_posts(context["request"])
+        context["posts_list"] = instance.get_posts(context["request"], published_only=False)
         context["TRUNCWORDS_COUNT"] = get_setting("POSTS_LIST_TRUNCWORDS_COUNT")
         return context
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -182,8 +182,16 @@ class PluginTest(BaseTest):
         self.assertTrue(rendered.find(posts[0].get_absolute_url()) > -1)
         self.assertTrue(rendered.find(posts[1].get_absolute_url()) > -1)
         plugin.posts.remove(posts[1])
-
         rendered = self.render_plugin(pages[0], "en", plugin, edit=True)
+        self.assertTrue(rendered.find(posts[0].get_absolute_url()) > -1)
+        self.assertFalse(rendered.find(posts[1].get_absolute_url()) > -1)
+        posts[1].publish = False
+        posts[1].save()
+        plugin.posts.add(posts[1])
+        rendered = self.render_plugin(pages[0], "en", plugin, edit=True)
+        self.assertTrue(rendered.find(posts[0].get_absolute_url()) > -1)
+        self.assertTrue(rendered.find(posts[1].get_absolute_url()) > -1)
+        rendered = self.render_plugin(pages[0], "en", plugin, edit=False)
         self.assertTrue(rendered.find(posts[0].get_absolute_url()) > -1)
         self.assertFalse(rendered.find(posts[1].get_absolute_url()) > -1)
 


### PR DESCRIPTION
# Description

Make BlogFeaturedPostsPlugin show unpublished posts if in edit mode

## References

Fixes #850 

# Checklist

* [x] I have read the [contribution guide](https://djangocms-blog.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://djangocms-blog.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [x] Tests added
