### PR TITLE
feat: use autocomplete_fields for categories and sites fields

### DIFF
--- a/changes/869.feature
+++ b/changes/869.feature
@@ -1,0 +1,1 @@
+Add categories and sites to autocomplete_fields

--- a/djangocms_blog/admin.py
+++ b/djangocms_blog/admin.py
@@ -88,6 +88,7 @@ class SiteListFilter(admin.SimpleListFilter):
 @admin.register(BlogCategory)
 class BlogCategoryAdmin(ModelAppHookConfig, TranslatableAdmin):
     form = CategoryAdminForm
+    search_fields = ["translations__name"]
     list_display = [
         "name",
         "parent",
@@ -110,6 +111,7 @@ class PostAdmin(PlaceholderAdminMixin, FrontendEditableAdminMixin, ModelAppHookC
     form = PostAdminForm
     list_display = ["title", "author", "date_published", "app_config", "all_languages_column", "date_published_end"]
     search_fields = ("translations__title",)
+    autocomplete_fields = ["categories", "sites"]
     date_hierarchy = "date_published"
     raw_id_fields = ["author"]
     frontend_editable_fields = ("title", "abstract", "post_text")


### PR DESCRIPTION
# Description

Add `categories` and `sites` to `autocomplete_fields`

## References

Fix #869 

# Checklist

* [x] I have read the [contribution guide](https://djangocms-blog.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://djangocms-blog.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))